### PR TITLE
[Collector] Fix issue that collector start failed in the Windows environment

### DIFF
--- a/apm-collector/apm-collector-boot/bin/collectorService.bat
+++ b/apm-collector/apm-collector-boot/bin/collectorService.bat
@@ -17,5 +17,5 @@ if not defined JAVA_HOME (
  set _EXECJAVA=java
 )
 
-start "%COLLECTOR_PROCESS_TITLE%" %_EXECJAVA% "%COLLECTOR_OPTS%" -cp "%CLASSPATH%" CollectorBootStartUp
+start "%COLLECTOR_PROCESS_TITLE%" %_EXECJAVA% "%COLLECTOR_OPTS%" -cp "%CLASSPATH%" org.apache.skywalking.apm.collector.boot.CollectorBootStartUp
 endlocal


### PR DESCRIPTION
The bootstrap class in `collectorService.bat`  is incorrect and collector start failed in the Windows environment