### PR TITLE
[Agent-Plugin] Add support to MysqlDataSource

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/define/DriverInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/define/DriverInstrumentation.java
@@ -32,8 +32,6 @@ import static org.apache.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameM
 public class DriverInstrumentation extends AbstractDriverInstrumentation {
     @Override
     protected ClassMatch enhanceClass() {
-        return byMultiClassMatch("com.mysql.jdbc.Driver", "com.mysql.cj.jdbc.Driver"
-                    ,"com.mysql.jdbc.NonRegisteringDriver"  //Add this for support MysqlDataSource and MysqlXADatasource
-                );
+        return byMultiClassMatch("com.mysql.jdbc.Driver", "com.mysql.cj.jdbc.Driver", "com.mysql.jdbc.NonRegisteringDriver");
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/define/DriverInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/define/DriverInstrumentation.java
@@ -32,6 +32,8 @@ import static org.apache.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameM
 public class DriverInstrumentation extends AbstractDriverInstrumentation {
     @Override
     protected ClassMatch enhanceClass() {
-        return byMultiClassMatch("com.mysql.jdbc.Driver", "com.mysql.cj.jdbc.Driver");
+        return byMultiClassMatch("com.mysql.jdbc.Driver", "com.mysql.cj.jdbc.Driver"
+                    ,"com.mysql.jdbc.NonRegisteringDriver"  //Add this for support MysqlDataSource and MysqlXADatasource
+                );
     }
 }


### PR DESCRIPTION
MysqlDataSource use com.mysql.jdbc.NonRegisteringDriver，not com.mysql.jdbc.Driver.
Add it to Agent's mysql-5.x-plugin to support the application which using MysqlDataSource.  #699 
