### PR TITLE
[Agent]Add a ProtectiveShieldMatcher to prevent match exception.

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>9.4.2.v20170220</jetty.version>
         <grpc.version>1.8.0</grpc.version>
-        <bytebuddy.version>1.7.6</bytebuddy.version>
+        <bytebuddy.version>1.7.9</bytebuddy.version>
 
         <shade.package>org.apache.skywalking.apm.dependencies</shade.package>
         <shade.com.lmax.disruptor.source>com.lmax.disruptor</shade.com.lmax.disruptor.source>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/ILog.java
@@ -33,6 +33,8 @@ public interface ILog {
 
     void warn(String format, Object... arguments);
 
+    void warn(Throwable e, String format, Object... arguments);
+
     void error(String format, Throwable e);
 
     void error(Throwable e, String format, Object... arguments);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/NoopLogger.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/api/NoopLogger.java
@@ -26,9 +26,7 @@ package org.apache.skywalking.apm.agent.core.logging.api;
  * Created by xin on 2016/11/10.
  */
 public enum NoopLogger implements ILog {
-    INSTANCE {
-
-    };
+    INSTANCE;
 
     @Override
     public void info(String message) {
@@ -87,6 +85,12 @@ public enum NoopLogger implements ILog {
 
     @Override
     public void error(Throwable e, String format, Object... arguments) {
+
+    }
+
+
+    @Override
+    public void warn(Throwable e, String format, Object... arguments) {
 
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/EasyLogger.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/EasyLogger.java
@@ -106,6 +106,12 @@ public class EasyLogger implements ILog {
     }
 
     @Override
+    public void warn(Throwable e, String format, Object... arguments) {
+        if (isWarnEnable())
+            logger(LogLevel.WARN, replaceParam(format, arguments), e);
+    }
+
+    @Override
     public void error(String format, Throwable e) {
         if (isErrorEnable())
             logger(LogLevel.ERROR, format, e);

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
@@ -30,6 +30,7 @@ import org.apache.skywalking.apm.agent.core.plugin.bytebuddy.AbstractJunction;
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
 import org.apache.skywalking.apm.agent.core.plugin.match.IndirectMatch;
 import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.ProtectiveShieldMatcher;
 
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -98,6 +99,6 @@ public class PluginFinder {
                 judge = judge.or(((IndirectMatch)match).buildJunction());
             }
         }
-        return judge;
+        return new ProtectiveShieldMatcher(judge);
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.skywalking.apm.agent.core.plugin.match;
+
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+
+/**
+ * In same cases, some frameworks and libraries use some binary codes tech too. From the community feedback, some of
+ * them have compatible issues with byte-buddy core, which trigger "Can't resolve type description" exception.
+ *
+ * So I build this protective shield by a nested matcher. When the origin matcher(s) can't resolve the type, the
+ * SkyWalking agent ignores this types.
+ *
+ * Notice: this ignore mechanism may miss some instrumentations, but at most cases, it's same. If missing happens,
+ * please pay attention to the WARNING logs.
+ *
+ * @author wu-sheng
+ */
+public class ProtectiveShieldMatcher<T> extends ElementMatcher.Junction.AbstractBase<T> {
+    private static final ILog logger = LogManager.getLogger(ProtectiveShieldMatcher.class);
+
+    private final ElementMatcher<? super T> matcher;
+
+    public ProtectiveShieldMatcher(ElementMatcher<? super T> matcher) {
+        this.matcher = matcher;
+    }
+
+    public boolean matches(T target) {
+        try {
+            return this.matcher.matches(target);
+        } catch (Throwable t) {
+            logger.warn(t, "Byte-buddy occurs exception when match type.");
+            return false;
+        }
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ProtectiveShieldMatcher.java
@@ -22,7 +22,7 @@ import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 
 /**
- * In same cases, some frameworks and libraries use some binary codes tech too. From the community feedback, some of
+ * In some cases, some frameworks and libraries use some binary codes tech too. From the community feedback, some of
  * them have compatible issues with byte-buddy core, which trigger "Can't resolve type description" exception.
  *
  * So I build this protective shield by a nested matcher. When the origin matcher(s) can't resolve the type, the


### PR DESCRIPTION
 In some cases, some frameworks and libraries use some binary codes tech too. From the community feedback, some of
them have compatible issues with byte-buddy core, which trigger "Can't resolve type description" exception.

So I build this protective shield by a nested matcher. When the origin matcher(s) can't resolve the type, the
SkyWalking agent ignores this types.

Notice: this ignore mechanism may miss some instrumentations, but at most cases, it's same. If missing happens, please pay attention to the WARNING logs.

FYI @peng-yongsheng @ascrutae 

This related to #578 #555 , from the Raphew's help: https://github.com/raphw/byte-buddy/issues/373