### PR TITLE
Provide the getServerThroughput query.

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceMetricUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceMetricUIDAO.java
@@ -30,7 +30,7 @@ import org.apache.skywalking.apm.collector.storage.utils.DurationPoint;
  */
 public interface IInstanceMetricUIDAO extends DAO {
 
-    List<AppServerInfo> getTopNServerThroughput(int applicationId, Step step, long start, long end, long secondBetween,
+    List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end, long secondBetween,
         int topN,
         MetricSource metricSource);
 

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceMetricEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceMetricEsUIDAO.java
@@ -58,7 +58,7 @@ public class InstanceMetricEsUIDAO extends EsDAO implements IInstanceMetricUIDAO
         super(client);
     }
 
-    @Override public List<AppServerInfo> getTopNServerThroughput(int applicationId, Step step, long start, long end,
+    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end,
         long secondBetween, int topN, MetricSource metricSource) {
         String tableName = TimePyramidTableNameBuilder.build(step, InstanceMetricTable.TABLE);
 

--- a/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceMetricH2UIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceMetricH2UIDAO.java
@@ -49,7 +49,7 @@ public class InstanceMetricH2UIDAO extends H2DAO implements IInstanceMetricUIDAO
         super(client);
     }
 
-    @Override public List<AppServerInfo> getTopNServerThroughput(int applicationId, Step step, long start, long end,
+    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end,
         long secondBetween, int topN, MetricSource metricSource) {
         return null;
     }

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
@@ -36,6 +36,8 @@ import org.apache.skywalking.apm.collector.storage.dao.ui.IGCMetricUIDAO;
 import org.apache.skywalking.apm.collector.storage.dao.ui.IInstanceMetricUIDAO;
 import org.apache.skywalking.apm.collector.storage.dao.ui.IInstanceUIDAO;
 import org.apache.skywalking.apm.collector.storage.dao.ui.IMemoryMetricUIDAO;
+import org.apache.skywalking.apm.collector.storage.table.MetricSource;
+import org.apache.skywalking.apm.collector.storage.table.register.Instance;
 import org.apache.skywalking.apm.collector.storage.ui.common.ResponseTimeTrend;
 import org.apache.skywalking.apm.collector.storage.ui.common.Step;
 import org.apache.skywalking.apm.collector.storage.ui.common.ThroughputTrend;
@@ -95,6 +97,21 @@ public class ServerService {
         List<Integer> trends = instanceMetricUIDAO.getResponseTimeTrend(instanceId, step, durationPoints);
         responseTimeTrend.setTrendList(trends);
         return responseTimeTrend;
+    }
+
+    public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start,
+        long end, Integer topN) throws ParseException {
+        //TODO
+        List<AppServerInfo> serverThroughput = instanceMetricUIDAO.getServerThroughput(applicationId, step, start, end, 1000, topN, MetricSource.Callee);
+        serverThroughput.forEach(appServerInfo -> {
+            String applicationCode = applicationCacheService.getApplicationById(applicationId).getApplicationCode();
+            appServerInfo.setApplicationCode(applicationCode);
+            Instance instance = instanceUIDAO.getInstance(appServerInfo.getId());
+            appServerInfo.setOsInfo(instance.getOsInfo());
+        });
+
+        buildAppServerInfo(serverThroughput);
+        return serverThroughput;
     }
 
     public ThroughputTrend getServerTPSTrend(int instanceId, Step step, long start, long end) throws ParseException {

--- a/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/application-layer.graphqls
+++ b/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/application-layer.graphqls
@@ -43,6 +43,6 @@ type Application {
 extend type Query {
   getAllApplication(duration: Duration!): [Application!]!
   getApplicationTopology(applicationId: ID!, duration: Duration!): Topology
-  getSlowService(applicationId: ID!, duration: Duration!, top: Int!): [ServiceMetric!]!
-  getServerThroughput(applicationId: ID!, duration: Duration!, top: Int!): [AppServerInfo!]!
+  getSlowService(applicationId: ID!, duration: Duration!, topN: Int!): [ServiceMetric!]!
+  getServerThroughput(applicationId: ID!, duration: Duration!, topN: Int!): [AppServerInfo!]!
 }


### PR DESCRIPTION
H2 DAO's implementation is empty.

Changed the parameter name from top to topN in getSlowService and getServerThroughput method. 

 #### INPUT
```
{
  getServerThroughput(applicationId: 2, duration: {start: "2017-01", end: "2018-02", step: MONTH}, topN: 10) {
    id
    applicationId
    applicationCode
    tps
    name
    host
    pid
    ipv4
  }
}
```

 #### OUTPUT
```
{
  "data": {
    "getServerThroughput": [
      {
        "id": "3",
        "applicationId": 2,
        "applicationCode": "dubbox-provider",
        "tps": 0,
        "name": "MacOS X",
        "host": "peng-yongsheng",
        "pid": 1000,
        "ipv4": [
          "10.0.0.1",
          "10.0.0.2"
        ]
      }
    ]
  }
}
```