### PR TITLE
Change the elasticsearch analyzer type to stop that can tokenizer the…

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/base/define/ElasticSearchStorageInstaller.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/base/define/ElasticSearchStorageInstaller.java
@@ -16,20 +16,19 @@
  *
  */
 
-
 package org.apache.skywalking.apm.collector.storage.es.base.define;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.skywalking.apm.collector.client.Client;
 import org.apache.skywalking.apm.collector.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.apm.collector.core.data.ColumnDefine;
+import org.apache.skywalking.apm.collector.core.data.TableDefine;
 import org.apache.skywalking.apm.collector.storage.StorageInstaller;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.apache.skywalking.apm.collector.client.Client;
-import org.apache.skywalking.apm.collector.core.data.ColumnDefine;
-import org.apache.skywalking.apm.collector.core.data.TableDefine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,9 +81,7 @@ public class ElasticSearchStorageInstaller extends StorageInstaller {
             .put("index.number_of_replicas", indexReplicasNumber)
             .put("index.refresh_interval", String.valueOf(tableDefine.refreshInterval()) + "s")
 
-            .put("analysis.analyzer.collector_analyzer.tokenizer", "collector_tokenizer")
-            .put("analysis.tokenizer.collector_tokenizer.type", "standard")
-            .put("analysis.tokenizer.collector_tokenizer.max_token_length", 5)
+            .put("analysis.analyzer.collector_analyzer.type", "stop")
             .build();
     }
 
@@ -100,7 +97,7 @@ public class ElasticSearchStorageInstaller extends StorageInstaller {
                 mappingBuilder
                     .startObject(elasticSearchColumnDefine.getName())
                     .field("type", elasticSearchColumnDefine.getType().toLowerCase())
-                    .field("fielddata", true)
+                    .field("analyzer", "collector_analyzer")
                     .endObject();
             } else {
                 mappingBuilder


### PR DESCRIPTION
… sentence such as “ org.apache.skywalking” to “org” “apache” “skywalking”

#### INPUT
```
query SearchService($keyword: String!) {
  searchService(keyword: $keyword, topN: 10) {
    key: id
    label: name
  }
}

{
  "keyword": "org"
}
```

#### OUTPUT
```
{
  "data": {
    "searchService": [
      {
        "key": "-1",
        "label": "org.skywaking.apm.testcase.dubbo.services.GreetService.doBusiness()"
      },
      {
        "key": "2",
        "label": "org.skywaking.apm.testcase.dubbo.services.GreetService.doBusiness()"
      }
    ]
  }
}
```