### PR TITLE
Update assembly.xml

### DIFF
--- a/apm-collector/apm-collector-boot/src/main/assembly/assembly.xml
+++ b/apm-collector/apm-collector-boot/src/main/assembly/assembly.xml
@@ -20,7 +20,7 @@
     xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <id></id>
+    <id>assembly</id>
     <formats>
         <format>zip</format>
         <format>tar.gz</format>


### PR DESCRIPTION
fixed maven 3.3.9 build issue caused by empty assembly ID on Ubuntu 16.04.2 using OpenJDK 1.8.0_151.

[INFO] Building apm-collector-boot 5.0.0-alpha
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ apm-collector-boot ---
[INFO] Deleting /home/steve/skywalking/incubator-skywalking/apm-collector/apm-collector-boot/target
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (validate) @ apm-collector-boot ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.492 s
[INFO] Finished at: 2018-02-18T12:05:49-06:00
[INFO] Final Memory: 19M/235M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (validate) on project apm-collector-boot: Failed during checkstyle configuration: cannot initialize module Header - Unable to find: CHECKSTYLE_HEAD -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
