### PR TITLE
Adjust build guide document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Underlying technology is a distributed tracing system.
   * Use **@Trace** annotation for any methods you want to trace.
   * Integrate traceId into logs for log4j, log4j2 and logback.
 * Pure Java server implementation, provide RESTful and gRPC services. Compatibility with other language agents/SDKs. 
-* The UI released on [skywalking-ui](https://github.com/apache/incubator-skywalking-ui)
 
 # Document
 [![EN doc](https://img.shields.io/badge/document-English-blue.svg)](docs/README.md) [![cn doc](https://img.shields.io/badge/文档-中文版-blue.svg)](docs/README_ZH.md)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -58,7 +58,7 @@ This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDU
 - 自动化集成测试报告
   - [Java探针测试报告](https://github.com/SkywalkingTest/agent-integration-test-report)
 - 性能测试报告
-  - [Java探针测试报告](https://skywalkingtest.github.io/Agent-Benchmarks/)
+  - [Java探针测试报告](https://skywalkingtest.github.io/Agent-Benchmarks/)
 
 # Contact Us
 * 直接提交Issue

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,7 +15,7 @@ Apache SkyWalking | [English](README.md)
 
 
 * Java自动探针，**不需要修改应用程序源代码**
-  * 高性能探针，针对单实例5000tps的应用，在**全量采集的情况下**，只增加**10%**的CPU开销。
+  * 高性能探针，针对单实例5000tps的应用，在**全量采集的情况下**，只增加 **10%** 的CPU开销。
   * [中间件，框架与类库支持列表](docs/Supported-list.md).
 * 手动探针
   * [使用OpenTracing手动探针API](http://opentracing.io/documentation/pages/supported-tracers)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -23,8 +23,6 @@ Apache SkyWalking | [English](README.md)
   * 将 traceId 集成到 log4j, log4j2 或 logback这些日志组件中
 * 纯Java后端Collector实现，提供RESTful和gRPC接口。兼容接受其他语言探针发送数据 
   * [如何将探针的Metric和Trace数据上传到Collector？](/docs/cn/How-to-communicate-with-the-collector-CN.md)
-* UI工程请查看 [skywalking-ui](https://github.com/apache/incubator-skywalking-ui)
-* 中文QQ群：392443393
 
 # Document
 [![EN doc](https://img.shields.io/badge/document-English-blue.svg)](docs/README.md) [![cn doc](https://img.shields.io/badge/文档-中文版-blue.svg)](docs/README_ZH.md)

--- a/docs/cn/How-to-build-CN.md
+++ b/docs/cn/How-to-build-CN.md
@@ -6,6 +6,9 @@
 
 ### 编译步骤
 1. 准备环境，jdk8，Maven
+1. `git clone https://github.com/apache/incubator-skywalking.git`
+1. `git submodule init`
+1. `git submodule update`
 1. 执行`mvn clean package`
 1. 生成包在`/packages`目录下，包括一个`skywalking-agent`的探针目录，以及两个collector包（.tar.gz是linux环境，.zip是windows环境）
 

--- a/docs/en/How-to-build.md
+++ b/docs/en/How-to-build.md
@@ -3,6 +3,9 @@ This document helps people to compile and build the project in your maven and ID
 
 ## Build in maven
 1. Prepare JDK8 and maven3
+1. `git clone https://github.com/apache/incubator-skywalking.git`
+1. `git submodule init`
+1. `git submodule update`
 1. Run `mvn clean package`
 1. All packages are in `/packages`, which includes `skywalking-agent` folder, and two collector files(.tar.gz for Linux and .zip for Windows)
 


### PR DESCRIPTION
I proposal to use `git submodule` to independent `proto define files` and integrate SkyWalking-UI into the main repository. I use this pull request to fix our `How to build` document, in case our developers are not familiar with `git submodule`.