### PR TITLE
"getTopNApplicationThroughput" service, change the attribute name from TPS to callsPerSec.

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IApplicationMetricUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IApplicationMetricUIDAO.java
@@ -28,8 +28,8 @@ import org.apache.skywalking.apm.collector.storage.ui.overview.ApplicationTPS;
  * @author peng-yongsheng
  */
 public interface IApplicationMetricUIDAO extends DAO {
-    List<ApplicationTPS> getTopNApplicationThroughput(Step step, long start, long end, long betweenSecond, int topN,
-        MetricSource metricSource);
+    List<ApplicationTPS> getTopNApplicationThroughput(Step step, long startTimeBucket, long endTimeBucket,
+        int betweenSecond, int topN, MetricSource metricSource);
 
     List<ApplicationMetric> getApplications(Step step, long startTimeBucket, long endTimeBucket,
         MetricSource metricSource);

--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/ui/overview/ApplicationTPS.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/ui/overview/ApplicationTPS.java
@@ -24,7 +24,7 @@ package org.apache.skywalking.apm.collector.storage.ui.overview;
 public class ApplicationTPS {
     private int applicationId;
     private String applicationCode;
-    private int tps;
+    private int callsPerSec;
 
     public int getApplicationId() {
         return applicationId;
@@ -42,11 +42,11 @@ public class ApplicationTPS {
         this.applicationCode = applicationCode;
     }
 
-    public int getTps() {
-        return tps;
+    public int getCallsPerSec() {
+        return callsPerSec;
     }
 
-    public void setTps(int tps) {
-        this.tps = tps;
+    public void setCallsPerSec(int callsPerSec) {
+        this.callsPerSec = callsPerSec;
     }
 }

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/ApplicationMetricEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/ApplicationMetricEsUIDAO.java
@@ -55,9 +55,8 @@ public class ApplicationMetricEsUIDAO extends EsDAO implements IApplicationMetri
     private static final String AVG_TPS = "avg_tps";
 
     @Override
-    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long start, long end, long betweenSecond,
-        int topN,
-        MetricSource metricSource) {
+    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long startTimeBucket, long endTimeBucket,
+        int betweenSecond, int topN, MetricSource metricSource) {
         String tableName = TimePyramidTableNameBuilder.build(step, ApplicationMetricTable.TABLE);
 
         SearchRequestBuilder searchRequestBuilder = getClient().prepareSearch(tableName);
@@ -65,7 +64,7 @@ public class ApplicationMetricEsUIDAO extends EsDAO implements IApplicationMetri
         searchRequestBuilder.setSearchType(SearchType.DFS_QUERY_THEN_FETCH);
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        boolQuery.must().add(QueryBuilders.rangeQuery(ApplicationMetricTable.COLUMN_TIME_BUCKET).gte(start).lte(end));
+        boolQuery.must().add(QueryBuilders.rangeQuery(ApplicationMetricTable.COLUMN_TIME_BUCKET).gte(startTimeBucket).lte(endTimeBucket));
         boolQuery.must().add(QueryBuilders.termQuery(ApplicationMetricTable.COLUMN_SOURCE_VALUE, metricSource.getValue()));
 
         searchRequestBuilder.setQuery(boolQuery);
@@ -97,7 +96,7 @@ public class ApplicationMetricEsUIDAO extends EsDAO implements IApplicationMetri
             InternalSimpleValue simpleValue = applicationIdTerm.getAggregations().get(AVG_TPS);
 
             applicationTPS.setApplicationId(applicationId);
-            applicationTPS.setTps((int)simpleValue.getValue());
+            applicationTPS.setCallsPerSec((int)simpleValue.getValue());
             applicationTPSs.add(applicationTPS);
         });
         return applicationTPSs;

--- a/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/ApplicationMetricH2UIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/ApplicationMetricH2UIDAO.java
@@ -40,8 +40,8 @@ public class ApplicationMetricH2UIDAO extends H2DAO implements IApplicationMetri
     }
 
     @Override
-    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long start, long end, long betweenSecond,
-        int topN, MetricSource metricSource) {
+    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long startTimeBucket, long endTimeBucket,
+        int betweenSecond, int topN, MetricSource metricSource) {
         return null;
     }
 

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/OverViewLayerQuery.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/OverViewLayerQuery.java
@@ -157,9 +157,9 @@ public class OverViewLayerQuery implements Query {
 
     public List<ApplicationTPS> getTopNApplicationThroughput(Duration duration,
         int topN) throws ParseException {
-        long start = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
-        long end = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
+        long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
+        long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getApplicationService().getTopNApplicationThroughput(duration.getStep(), start, end, topN);
+        return getApplicationService().getTopNApplicationThroughput(duration.getStep(), startTimeBucket, endTimeBucket, topN);
     }
 }

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ApplicationService.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ApplicationService.java
@@ -37,6 +37,7 @@ import org.apache.skywalking.apm.collector.storage.ui.overview.ApplicationTPS;
 import org.apache.skywalking.apm.collector.storage.ui.overview.ConjecturalApp;
 import org.apache.skywalking.apm.collector.storage.ui.overview.ConjecturalAppBrief;
 import org.apache.skywalking.apm.collector.storage.ui.service.ServiceMetric;
+import org.apache.skywalking.apm.collector.ui.utils.DurationUtils;
 
 /**
  * @author peng-yongsheng
@@ -80,10 +81,10 @@ public class ApplicationService {
         return slowServices;
     }
 
-    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long start, long end,
+    public List<ApplicationTPS> getTopNApplicationThroughput(Step step, long startTimeBucket, long endTimeBucket,
         int topN) throws ParseException {
-        //TODO
-        List<ApplicationTPS> applicationThroughput = applicationMetricUIDAO.getTopNApplicationThroughput(step, start, end, 1000, topN, MetricSource.Callee);
+        int secondsBetween = DurationUtils.INSTANCE.secondsBetween(step, startTimeBucket, endTimeBucket);
+        List<ApplicationTPS> applicationThroughput = applicationMetricUIDAO.getTopNApplicationThroughput(step, startTimeBucket, endTimeBucket, secondsBetween, topN, MetricSource.Callee);
         applicationThroughput.forEach(applicationTPS -> {
             String applicationCode = applicationCacheService.getApplicationById(applicationTPS.getApplicationId()).getApplicationCode();
             applicationTPS.setApplicationCode(applicationCode);

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/utils/DurationUtils.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/utils/DurationUtils.java
@@ -64,36 +64,36 @@ public enum DurationUtils {
         return secondTimeBucket;
     }
 
-    public long secondsBetween(Step step, long start, long end) throws ParseException {
+    public int secondsBetween(Step step, long startTimeBucket, long endTimeBucket) throws ParseException {
         Date startDate = null;
         Date endDate = null;
         switch (step) {
             case MONTH:
-                startDate = new SimpleDateFormat("yyyyMM").parse(String.valueOf(start));
-                endDate = new SimpleDateFormat("yyyyMM").parse(String.valueOf(end));
+                startDate = new SimpleDateFormat("yyyyMM").parse(String.valueOf(startTimeBucket));
+                endDate = new SimpleDateFormat("yyyyMM").parse(String.valueOf(endTimeBucket));
                 break;
             case DAY:
-                startDate = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(start));
-                endDate = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(end));
+                startDate = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(startTimeBucket));
+                endDate = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(endTimeBucket));
                 break;
             case HOUR:
-                startDate = new SimpleDateFormat("yyyyMMddHH").parse(String.valueOf(start));
-                endDate = new SimpleDateFormat("yyyyMMddHH").parse(String.valueOf(end));
+                startDate = new SimpleDateFormat("yyyyMMddHH").parse(String.valueOf(startTimeBucket));
+                endDate = new SimpleDateFormat("yyyyMMddHH").parse(String.valueOf(endTimeBucket));
                 break;
             case MINUTE:
-                startDate = new SimpleDateFormat("yyyyMMddHHmm").parse(String.valueOf(start));
-                endDate = new SimpleDateFormat("yyyyMMddHHmm").parse(String.valueOf(end));
+                startDate = new SimpleDateFormat("yyyyMMddHHmm").parse(String.valueOf(startTimeBucket));
+                endDate = new SimpleDateFormat("yyyyMMddHHmm").parse(String.valueOf(endTimeBucket));
                 break;
             case SECOND:
-                startDate = new SimpleDateFormat("yyyyMMddHHmmss").parse(String.valueOf(start));
-                endDate = new SimpleDateFormat("yyyyMMddHHmmss").parse(String.valueOf(end));
+                startDate = new SimpleDateFormat("yyyyMMddHHmmss").parse(String.valueOf(startTimeBucket));
+                endDate = new SimpleDateFormat("yyyyMMddHHmmss").parse(String.valueOf(endTimeBucket));
                 break;
         }
 
         return Seconds.secondsBetween(new DateTime(startDate), new DateTime(endDate)).getSeconds();
     }
 
-    public long secondsBetween(Step step, DateTime dateTime) throws ParseException {
+    public int secondsBetween(Step step, DateTime dateTime) throws ParseException {
         switch (step) {
             case MONTH:
                 return dateTime.dayOfMonth().getMaximumValue() * 24 * 60 * 60;

--- a/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/overview-layer.graphqls
+++ b/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/overview-layer.graphqls
@@ -30,7 +30,7 @@ type ConjecturalApp {
 type ApplicationTPS {
     applicationId: Int!
     applicationCode: String
-    tps: Int!
+    callsPerSec: Int!
 }
 
 extend type Query {


### PR DESCRIPTION
1. Changed the attribute name from TPS to callsPerSec.
2. Calculate the callsPerSec.

#### INPUT
```
{
  getTopNApplicationThroughput(duration: {start: "2017-06-01 1002", end: "2017-06-01 1005", step: MINUTE}, topN: 10) {
    applicationId, applicationCode, callsPerSec
  }
}
```

#### OUTPUT
```
{
  "data": {
    "getTopNApplicationThroughput": [
      {
        "applicationId": -1,
        "applicationCode": "dubbox-consumer",
        "callsPerSec": 20
      },
      {
        "applicationId": 2,
        "applicationCode": "dubbox-provider",
        "callsPerSec": 20
      }
    ]
  }
}
```