### PR TITLE
"getSlowService" Calculate callsPerSec metric.

### DIFF
--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ApplicationQuery.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ApplicationQuery.java
@@ -87,10 +87,13 @@ public class ApplicationQuery implements Query {
 
     public List<ServiceMetric> getSlowService(int applicationId, Duration duration,
         Integer topN) throws ParseException {
-        long start = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
-        long end = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
+        long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
+        long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getApplicationService().getSlowService(applicationId, duration.getStep(), start, end, topN);
+        long startSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
+        long endSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
+
+        return getApplicationService().getSlowService(applicationId, duration.getStep(), startTimeBucket, endTimeBucket, startSecondTimeBucket, endSecondTimeBucket, topN);
     }
 
     public List<AppServerInfo> getServerThroughput(int applicationId, Duration duration,


### PR DESCRIPTION
1. Changed the attribute name from TPS to callsPerSec.

#### INPUT
```
{
  getSlowService(applicationId: 2, duration: {start: "2017-06-01 1002", end: "2017-06-01 1005", step: MINUTE}, topN: 10) {
    id, name, avgResponseTime, callsPerSec
  }
}
```

#### OUTPUT
```
{
  "data": {
    "getSlowService": [
      {
        "id": "2",
        "name": "org.skywaking.apm.testcase.dubbo.services.GreetService.doBusiness()",
        "avgResponseTime": 1000,
        "callsPerSec": 20
      }
    ]
  }
}
```