### PR TITLE
"getServerThroughput" Changed the attribute name from TPS to callsPerSec.

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceMetricUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceMetricUIDAO.java
@@ -30,9 +30,8 @@ import org.apache.skywalking.apm.collector.storage.utils.DurationPoint;
  */
 public interface IInstanceMetricUIDAO extends DAO {
 
-    List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end, long secondBetween,
-        int topN,
-        MetricSource metricSource);
+    List<AppServerInfo> getServerThroughput(int applicationId, Step step, long startTimeBucket, long endTimeBucket,
+        int secondBetween, int topN, MetricSource metricSource);
 
     List<Integer> getServerTPSTrend(int instanceId, Step step, List<DurationPoint> durationPoints);
 

--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/ui/server/AppServerInfo.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/ui/server/AppServerInfo.java
@@ -29,7 +29,7 @@ public class AppServerInfo {
     private String applicationCode;
     private String osInfo;
     private String name;
-    private int tps;
+    private int callsPerSec;
     private String host;
     private int pid;
     private List<String> ipv4;
@@ -74,12 +74,12 @@ public class AppServerInfo {
         this.name = name;
     }
 
-    public int getTps() {
-        return tps;
+    public int getCallsPerSec() {
+        return callsPerSec;
     }
 
-    public void setTps(int tps) {
-        this.tps = tps;
+    public void setCallsPerSec(int callsPerSec) {
+        this.callsPerSec = callsPerSec;
     }
 
     public String getHost() {

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceMetricEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceMetricEsUIDAO.java
@@ -58,8 +58,8 @@ public class InstanceMetricEsUIDAO extends EsDAO implements IInstanceMetricUIDAO
         super(client);
     }
 
-    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end,
-        long secondBetween, int topN, MetricSource metricSource) {
+    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long startTimeBucket, long endTimeBucket,
+        int secondBetween, int topN, MetricSource metricSource) {
         String tableName = TimePyramidTableNameBuilder.build(step, InstanceMetricTable.TABLE);
 
         SearchRequestBuilder searchRequestBuilder = getClient().prepareSearch(tableName);
@@ -67,7 +67,7 @@ public class InstanceMetricEsUIDAO extends EsDAO implements IInstanceMetricUIDAO
         searchRequestBuilder.setSearchType(SearchType.DFS_QUERY_THEN_FETCH);
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceMetricTable.COLUMN_TIME_BUCKET).gte(start).lte(end));
+        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceMetricTable.COLUMN_TIME_BUCKET).gte(startTimeBucket).lte(endTimeBucket));
         if (applicationId != 0) {
             boolQuery.must().add(QueryBuilders.termQuery(InstanceMetricTable.COLUMN_APPLICATION_ID, applicationId));
         }
@@ -102,7 +102,7 @@ public class InstanceMetricEsUIDAO extends EsDAO implements IInstanceMetricUIDAO
             InternalSimpleValue simpleValue = serviceIdTerm.getAggregations().get(AVG_TPS);
 
             appServerInfo.setId(instanceId);
-            appServerInfo.setTps((int)simpleValue.getValue());
+            appServerInfo.setCallsPerSec((int)simpleValue.getValue());
             appServerInfos.add(appServerInfo);
         });
         return appServerInfos;

--- a/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceMetricH2UIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceMetricH2UIDAO.java
@@ -49,8 +49,8 @@ public class InstanceMetricH2UIDAO extends H2DAO implements IInstanceMetricUIDAO
         super(client);
     }
 
-    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long start, long end,
-        long secondBetween, int topN, MetricSource metricSource) {
+    @Override public List<AppServerInfo> getServerThroughput(int applicationId, Step step, long startTimeBucket, long endTimeBucket,
+        int secondBetween, int topN, MetricSource metricSource) {
         return null;
     }
 

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ApplicationQuery.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ApplicationQuery.java
@@ -98,9 +98,12 @@ public class ApplicationQuery implements Query {
 
     public List<AppServerInfo> getServerThroughput(int applicationId, Duration duration,
         Integer topN) throws ParseException {
-        long start = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
-        long end = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
+        long startTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getStart());
+        long endTimeBucket = DurationUtils.INSTANCE.exchangeToTimeBucket(duration.getEnd());
 
-        return getServerService().getServerThroughput(applicationId, duration.getStep(), start, end, topN);
+        long startSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
+        long endSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
+
+        return getServerService().getServerThroughput(applicationId, duration.getStep(), startTimeBucket, endTimeBucket, startSecondTimeBucket, endSecondTimeBucket, topN);
     }
 }

--- a/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/server-layer.graphqls
+++ b/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/server-layer.graphqls
@@ -8,7 +8,7 @@ type AppServerInfo {
     name: String!
     applicationId: Int!
     applicationCode: String
-    tps: Int!
+    callsPerSec: Int!
     host: String
     pid: Int
     ipv4: [String!]!


### PR DESCRIPTION
1. Changed the attribute name from TPS to callsPerSec.

#### INPUT
```
{
  getServerThroughput(applicationId: 2, duration: {start: "2017-06-01 1002", end: "2017-06-01 1005", step: MINUTE}, topN: 10) {
    id
    applicationId
    applicationCode
    callsPerSec
    name
    host
    pid
    ipv4
  }
}
```

#### OUTPUT
```
{
  "data": {
    "getServerThroughput": [
      {
        "id": "3",
        "applicationId": 2,
        "applicationCode": "dubbox-provider",
        "callsPerSec": 20,
        "name": "MacOS X",
        "host": "peng-yongsheng",
        "pid": 1000,
        "ipv4": [
          "10.0.0.1",
          "10.0.0.2"
        ]
      }
    ]
  }
}
```