### PR TITLE
"searchServer" and "getAllServer"

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-define/src/main/java/org/apache/skywalking/apm/collector/storage/dao/ui/IInstanceUIDAO.java
@@ -36,7 +36,7 @@ public interface IInstanceUIDAO extends DAO {
 
     Instance getInstance(int instanceId);
 
-    List<AppServerInfo> searchServer(String keyword, long start, long end);
+    List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket);
 
     List<AppServerInfo> getAllServer(int applicationId, long startSecondTimeBucket, long endSecondTimeBucket);
 

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceEsUIDAO.java
@@ -150,15 +150,15 @@ public class InstanceEsUIDAO extends EsDAO implements IInstanceUIDAO {
         return null;
     }
 
-    @Override public List<AppServerInfo> searchServer(String keyword, long start, long end) {
-        logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, start, end);
+    @Override public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
+        logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, startSecondTimeBucket, endSecondTimeBucket);
         SearchRequestBuilder searchRequestBuilder = getClient().prepareSearch(InstanceTable.TABLE);
         searchRequestBuilder.setTypes(InstanceTable.TABLE_TYPE);
         searchRequestBuilder.setSearchType(SearchType.DFS_QUERY_THEN_FETCH);
         searchRequestBuilder.setSize(1000);
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(start).lte(end));
+        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
         if (StringUtils.isNotEmpty(keyword)) {
             boolQuery.must().add(QueryBuilders.queryStringQuery(keyword));
         }

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/InstanceEsUIDAO.java
@@ -97,7 +97,8 @@ public class InstanceEsUIDAO extends EsDAO implements IInstanceUIDAO {
         return heartBeatTime;
     }
 
-    @Override public List<Application> getApplications(long startSecondTimeBucket, long endSecondTimeBucket, int... applicationIds) {
+    @Override public List<Application> getApplications(long startSecondTimeBucket, long endSecondTimeBucket,
+        int... applicationIds) {
         logger.debug("application list get, start time: {}, end time: {}", startSecondTimeBucket, endSecondTimeBucket);
         SearchRequestBuilder searchRequestBuilder = getClient().prepareSearch(InstanceTable.TABLE);
         searchRequestBuilder.setTypes(InstanceTable.TABLE_TYPE);
@@ -150,7 +151,8 @@ public class InstanceEsUIDAO extends EsDAO implements IInstanceUIDAO {
         return null;
     }
 
-    @Override public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
+    @Override
+    public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
         logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, startSecondTimeBucket, endSecondTimeBucket);
         SearchRequestBuilder searchRequestBuilder = getClient().prepareSearch(InstanceTable.TABLE);
         searchRequestBuilder.setTypes(InstanceTable.TABLE_TYPE);
@@ -158,11 +160,17 @@ public class InstanceEsUIDAO extends EsDAO implements IInstanceUIDAO {
         searchRequestBuilder.setSize(1000);
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
         if (StringUtils.isNotEmpty(keyword)) {
             boolQuery.must().add(QueryBuilders.queryStringQuery(keyword));
         }
         boolQuery.must().add(QueryBuilders.termQuery(InstanceTable.COLUMN_IS_ADDRESS, BooleanUtils.FALSE));
+
+        BoolQueryBuilder timeBoolQuery = QueryBuilders.boolQuery();
+        timeBoolQuery.should().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_REGISTER_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
+        timeBoolQuery.should().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
+
+        boolQuery.must().add(timeBoolQuery);
+
         searchRequestBuilder.setQuery(boolQuery);
 
         SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
@@ -180,11 +188,14 @@ public class InstanceEsUIDAO extends EsDAO implements IInstanceUIDAO {
         searchRequestBuilder.setSize(1000);
 
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_REGISTER_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
-        boolQuery.must().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(startSecondTimeBucket));
-
         boolQuery.must().add(QueryBuilders.termQuery(InstanceTable.COLUMN_APPLICATION_ID, applicationId));
         boolQuery.must().add(QueryBuilders.termQuery(InstanceTable.COLUMN_IS_ADDRESS, BooleanUtils.FALSE));
+
+        BoolQueryBuilder timeBoolQuery = QueryBuilders.boolQuery();
+        timeBoolQuery.should().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_REGISTER_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
+        timeBoolQuery.should().add(QueryBuilders.rangeQuery(InstanceTable.COLUMN_HEARTBEAT_TIME).gte(startSecondTimeBucket).lte(endSecondTimeBucket));
+
+        boolQuery.must().add(timeBoolQuery);
         searchRequestBuilder.setQuery(boolQuery);
 
         SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();

--- a/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceH2UIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceH2UIDAO.java
@@ -88,7 +88,8 @@ public class InstanceH2UIDAO extends H2DAO implements IInstanceUIDAO {
     }
 
     @Override
-    public List<Application> getApplications(long startSecondTimeBucket, long endSecondTimeBucket, int... applicationIds) {
+    public List<Application> getApplications(long startSecondTimeBucket, long endSecondTimeBucket,
+        int... applicationIds) {
         H2Client client = getClient();
         List<Application> applications = new LinkedList<>();
         String sql = SqlBuilder.buildSql(GET_APPLICATIONS_SQL, InstanceTable.COLUMN_INSTANCE_ID,
@@ -131,20 +132,21 @@ public class InstanceH2UIDAO extends H2DAO implements IInstanceUIDAO {
         return null;
     }
 
-    @Override public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
+    @Override
+    public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
         logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, startSecondTimeBucket, endSecondTimeBucket);
-        String dynamicSql = "select * from {0} where {1} like ? and {2} >= ? and {2} <= ? and {3} = ?";
-        String sql = SqlBuilder.buildSql(dynamicSql, InstanceTable.TABLE, InstanceTable.COLUMN_OS_INFO, InstanceTable.COLUMN_HEARTBEAT_TIME, InstanceTable.COLUMN_IS_ADDRESS);
-        Object[] params = new Object[] {keyword, startSecondTimeBucket, endSecondTimeBucket, BooleanUtils.FALSE};
+        String dynamicSql = "select * from {0} where {1} like ? and (({2} >= ? and {2} <= ?) or ({3} >= ? and {3} <= ?)) and {4} = ?";
+        String sql = SqlBuilder.buildSql(dynamicSql, InstanceTable.TABLE, InstanceTable.COLUMN_OS_INFO, InstanceTable.COLUMN_REGISTER_TIME, InstanceTable.COLUMN_HEARTBEAT_TIME, InstanceTable.COLUMN_IS_ADDRESS);
+        Object[] params = new Object[] {keyword, startSecondTimeBucket, endSecondTimeBucket, startSecondTimeBucket, endSecondTimeBucket, BooleanUtils.FALSE};
         return buildAppServerInfo(sql, params);
     }
 
     @Override
     public List<AppServerInfo> getAllServer(int applicationId, long startSecondTimeBucket, long endSecondTimeBucket) {
         logger.debug("get instances info, applicationId: {}, startSecondTimeBucket: {}, endSecondTimeBucket: {}", applicationId, startSecondTimeBucket, endSecondTimeBucket);
-        String dynamicSql = "select * from {0} where {1} = ? and {2} >= ? and {2} <= ? and {3} >= ? and {4} = ?";
+        String dynamicSql = "select * from {0} where {1} = ? and (({2} >= ? and {2} <= ?) or ({3} >= ? and {3} <= ?)) and {4} = ?";
         String sql = SqlBuilder.buildSql(dynamicSql, InstanceTable.TABLE, InstanceTable.COLUMN_APPLICATION_ID, InstanceTable.COLUMN_REGISTER_TIME, InstanceTable.COLUMN_HEARTBEAT_TIME, InstanceTable.COLUMN_IS_ADDRESS);
-        Object[] params = new Object[] {applicationId, startSecondTimeBucket, endSecondTimeBucket, startSecondTimeBucket, BooleanUtils.FALSE};
+        Object[] params = new Object[] {applicationId, startSecondTimeBucket, endSecondTimeBucket, startSecondTimeBucket, endSecondTimeBucket, BooleanUtils.FALSE};
         return buildAppServerInfo(sql, params);
     }
 

--- a/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceH2UIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-h2-provider/src/main/java/org/apache/skywalking/apm/collector/storage/h2/dao/ui/InstanceH2UIDAO.java
@@ -131,11 +131,11 @@ public class InstanceH2UIDAO extends H2DAO implements IInstanceUIDAO {
         return null;
     }
 
-    @Override public List<AppServerInfo> searchServer(String keyword, long start, long end) {
-        logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, start, end);
+    @Override public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
+        logger.debug("get instances info, keyword: {}, start: {}, end: {}", keyword, startSecondTimeBucket, endSecondTimeBucket);
         String dynamicSql = "select * from {0} where {1} like ? and {2} >= ? and {2} <= ? and {3} = ?";
         String sql = SqlBuilder.buildSql(dynamicSql, InstanceTable.TABLE, InstanceTable.COLUMN_OS_INFO, InstanceTable.COLUMN_HEARTBEAT_TIME, InstanceTable.COLUMN_IS_ADDRESS);
-        Object[] params = new Object[] {keyword, start, end, BooleanUtils.FALSE};
+        Object[] params = new Object[] {keyword, startSecondTimeBucket, endSecondTimeBucket, BooleanUtils.FALSE};
         return buildAppServerInfo(sql, params);
     }
 

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ServerQuery.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ServerQuery.java
@@ -53,9 +53,9 @@ public class ServerQuery implements Query {
     }
 
     public List<AppServerInfo> searchServer(String keyword, Duration duration) throws ParseException {
-        long start = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
-        long end = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
-        return getServerService().searchServer(keyword, start, end);
+        long startSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
+        long endSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
+        return getServerService().searchServer(keyword, startSecondTimeBucket, endSecondTimeBucket);
     }
 
     public List<AppServerInfo> getAllServer(int applicationId, Duration duration) throws ParseException {

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ServerQuery.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/query/ServerQuery.java
@@ -59,9 +59,9 @@ public class ServerQuery implements Query {
     }
 
     public List<AppServerInfo> getAllServer(int applicationId, Duration duration) throws ParseException {
-        long start = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
-        long end = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
-        return getServerService().getAllServer(applicationId, start, end);
+        long startSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getStart());
+        long endSecondTimeBucket = DurationUtils.INSTANCE.durationToSecondTimeBucket(duration.getStep(), duration.getEnd());
+        return getServerService().getAllServer(applicationId, startSecondTimeBucket, endSecondTimeBucket);
     }
 
     public ResponseTimeTrend getServerResponseTimeTrend(int serverId, Duration duration) throws ParseException {

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
@@ -74,8 +74,8 @@ public class ServerService {
         this.secondBetweenService = new SecondBetweenService(moduleManager);
     }
 
-    public List<AppServerInfo> searchServer(String keyword, long start, long end) {
-        List<AppServerInfo> serverInfos = instanceUIDAO.searchServer(keyword, start, end);
+    public List<AppServerInfo> searchServer(String keyword, long startSecondTimeBucket, long endSecondTimeBucket) {
+        List<AppServerInfo> serverInfos = instanceUIDAO.searchServer(keyword, startSecondTimeBucket, endSecondTimeBucket);
         serverInfos.forEach(serverInfo -> {
             if (serverInfo.getId() == Const.NONE_INSTANCE_ID) {
                 serverInfos.remove(serverInfo);

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServerService.java
@@ -86,8 +86,8 @@ public class ServerService {
         return serverInfos;
     }
 
-    public List<AppServerInfo> getAllServer(int applicationId, long start, long end) {
-        List<AppServerInfo> serverInfos = instanceUIDAO.getAllServer(applicationId, start, end);
+    public List<AppServerInfo> getAllServer(int applicationId, long startSecondTimeBucket, long endSecondTimeBucket) {
+        List<AppServerInfo> serverInfos = instanceUIDAO.getAllServer(applicationId, startSecondTimeBucket, endSecondTimeBucket);
         buildAppServerInfo(serverInfos);
         return serverInfos;
     }


### PR DESCRIPTION
1. Change the parameter name:
Start -> startSecondTimeBucket
End -> endSecondTimeBucket

2. The time range of heart beat time and register time:
Start time >= register time <= end time
Start time >= heart beat time <= end time

### searchServer
#### INPUT
```
searchServer(keyword: "peng", duration: {start: "2018-01-01 011001", end: "2018-03-30 231001", step: SECOND}) {
    id, name, host, pid, ipv4
  }
```

#### OUTPUT
```
{
  "data": {
    "searchServer": [
      {
        "id": "3",
        "name": "MacOS X",
        "host": "peng-yongsheng",
        "pid": 1000,
        "ipv4": [
          "10.0.0.1",
          "10.0.0.2"
        ]
      }
    ]
  }
}
```

### getAllServer
#### INPUT
```
{
  getAllServer(applicationId: -1, duration: {start: "2017-10-01 011001", end: "2018-03-30 231001", step: SECOND}) {
    id, name, host, pid, ipv4
  }
}
```

#### OUTPUT
```
{
  "data": {
    "getAllServer": [
      {
        "id": "2",
        "name": "MacOS XX",
        "host": "pengys",
        "pid": 1001,
        "ipv4": [
          "10.0.0.3",
          "10.0.0.4"
        ]
      }
    ]
  }
}
```