### PR TITLE
change storage setting in default backend application.yml to h2

### DIFF
--- a/apm-collector/apm-collector-boot/src/main/resources/application.yml
+++ b/apm-collector/apm-collector-boot/src/main/resources/application.yml
@@ -34,18 +34,18 @@ ui:
     host: localhost
     port: 12800
     context_path: /
-storage:
-  elasticsearch:
-    cluster_name: CollectorDBCluster
-    cluster_transport_sniffer: true
-    cluster_nodes: localhost:9300
-    index_shards_number: 2
-    index_replicas_number: 0
-    ttl: 7
 #storage:
-#  h2:
-#    url: jdbc:h2:tcp://localhost/~/test
-#    user_name: sa
+#  elasticsearch:
+#    cluster_name: CollectorDBCluster
+#    cluster_transport_sniffer: true
+#    cluster_nodes: localhost:9300
+#    index_shards_number: 2
+#    index_replicas_number: 0
+#    ttl: 7
+storage:
+  h2:
+    url: jdbc:h2:tcp://localhost/~/test
+    user_name: sa
 configuration:
   default:
     application_apdex_threshold: 2000


### PR DESCRIPTION
…lasticsearch

Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
Default storage setting in default backend application.yml is elasticsearch not h2,may better let newbie startup(quick start) without any config.
In windows environment also difficult to know where problem is for collector failed because the Console windows will blink close without any log.
Screenshot with prt sc key :
![123](https://user-images.githubusercontent.com/374335/36896626-5a219462-1e4e-11e8-9b8f-eae40e79b053.png)

- How to fix?
change storage setting in default backend application.yml to h2
___
### New feature or improvement
- Describe the details and related test reports.
