### PR TITLE
Fixed/855

### DIFF
--- a/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/mapping/ApplicationMappingSpanListener.java
+++ b/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/mapping/ApplicationMappingSpanListener.java
@@ -34,6 +34,7 @@ import org.apache.skywalking.apm.collector.core.module.ModuleManager;
 import org.apache.skywalking.apm.collector.core.util.Const;
 import org.apache.skywalking.apm.collector.core.util.TimeBucketUtils;
 import org.apache.skywalking.apm.collector.storage.table.application.ApplicationMapping;
+import org.apache.skywalking.apm.network.proto.SpanLayer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,18 +55,20 @@ public class ApplicationMappingSpanListener implements FirstSpanListener, EntryS
 
     @Override public void parseEntry(SpanDecorator spanDecorator, int applicationId, int instanceId, String segmentId) {
         logger.debug("application mapping listener parse reference");
-        if (spanDecorator.getRefsCount() > 0) {
-            for (int i = 0; i < spanDecorator.getRefsCount(); i++) {
-                ApplicationMapping applicationMapping = new ApplicationMapping();
-                applicationMapping.setApplicationId(applicationId);
+        if (!spanDecorator.getSpanLayer().equals(SpanLayer.MQ)) {
+            if (spanDecorator.getRefsCount() > 0) {
+                for (int i = 0; i < spanDecorator.getRefsCount(); i++) {
+                    ApplicationMapping applicationMapping = new ApplicationMapping();
+                    applicationMapping.setApplicationId(applicationId);
 
-                int addressId = spanDecorator.getRefs(i).getNetworkAddressId();
-                int mappingApplicationId = applicationCacheService.getApplicationIdByAddressId(addressId);
-                applicationMapping.setMappingApplicationId(mappingApplicationId);
+                    int addressId = spanDecorator.getRefs(i).getNetworkAddressId();
+                    int mappingApplicationId = applicationCacheService.getApplicationIdByAddressId(addressId);
+                    applicationMapping.setMappingApplicationId(mappingApplicationId);
 
-                String metricId = String.valueOf(applicationId) + Const.ID_SPLIT + String.valueOf(applicationMapping.getMappingApplicationId());
-                applicationMapping.setMetricId(metricId);
-                applicationMappings.add(applicationMapping);
+                    String metricId = String.valueOf(applicationId) + Const.ID_SPLIT + String.valueOf(applicationMapping.getMappingApplicationId());
+                    applicationMapping.setMetricId(metricId);
+                    applicationMappings.add(applicationMapping);
+                }
             }
         }
     }

--- a/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/service/refmetric/ServiceReferenceMetricSpanListener.java
+++ b/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/service/refmetric/ServiceReferenceMetricSpanListener.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.apm.collector.analysis.metric.provider.worker.serv
 
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.skywalking.apm.collector.storage.table.MetricSource;
 import org.apache.skywalking.apm.collector.analysis.metric.define.graph.MetricGraphIdDefine;
 import org.apache.skywalking.apm.collector.analysis.segment.parser.define.decorator.ReferenceDecorator;
 import org.apache.skywalking.apm.collector.analysis.segment.parser.define.decorator.SpanDecorator;
@@ -38,6 +37,7 @@ import org.apache.skywalking.apm.collector.core.module.ModuleManager;
 import org.apache.skywalking.apm.collector.core.util.Const;
 import org.apache.skywalking.apm.collector.core.util.ObjectUtils;
 import org.apache.skywalking.apm.collector.core.util.TimeBucketUtils;
+import org.apache.skywalking.apm.collector.storage.table.MetricSource;
 import org.apache.skywalking.apm.collector.storage.table.service.ServiceReferenceMetric;
 import org.apache.skywalking.apm.network.proto.SpanLayer;
 import org.slf4j.Logger;
@@ -78,8 +78,17 @@ public class ServiceReferenceMetricSpanListener implements FirstSpanListener, En
                 ReferenceDecorator reference = spanDecorator.getRefs(i);
                 ServiceReferenceMetric serviceReferenceMetric = new ServiceReferenceMetric();
                 serviceReferenceMetric.setFrontServiceId(reference.getParentServiceId());
-                serviceReferenceMetric.setFrontInstanceId(reference.getParentApplicationInstanceId());
-                serviceReferenceMetric.setFrontApplicationId(instanceCacheService.getApplicationId(reference.getParentApplicationInstanceId()));
+
+                if (spanDecorator.getSpanLayer().equals(SpanLayer.MQ)) {
+                    int peerId = spanDecorator.getPeerId();
+                    int applicationIdByPeerId = applicationCacheService.getApplicationIdByAddressId(peerId);
+                    int instanceIdByPeerId = instanceCacheService.getInstanceIdByAddressId(applicationIdByPeerId, peerId);
+                    serviceReferenceMetric.setFrontInstanceId(instanceIdByPeerId);
+                    serviceReferenceMetric.setFrontApplicationId(applicationIdByPeerId);
+                } else {
+                    serviceReferenceMetric.setFrontInstanceId(reference.getParentApplicationInstanceId());
+                    serviceReferenceMetric.setFrontApplicationId(instanceCacheService.getApplicationId(reference.getParentApplicationInstanceId()));
+                }
                 serviceReferenceMetric.setBehindServiceId(spanDecorator.getOperationNameId());
                 serviceReferenceMetric.setBehindInstanceId(instanceId);
                 serviceReferenceMetric.setBehindApplicationId(applicationId);

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/utils/PaginationUtils.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/utils/PaginationUtils.java
@@ -28,7 +28,7 @@ public enum PaginationUtils {
 
     public Page exchange(Pagination paging) {
         int limit = paging.getPageSize();
-        int from = paging.getPageSize() * (paging.getPageNum() - 1);
+        int from = paging.getPageSize() * ((paging.getPageNum() == 0 ? 1 : paging.getPageNum()) - 1);
 
         return new Page(from, limit);
     }

--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/test/java/org/apache/skywalking/apm/collector/ui/utils/PaginationUtilsTestCase.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/test/java/org/apache/skywalking/apm/collector/ui/utils/PaginationUtilsTestCase.java
@@ -39,6 +39,13 @@ public class PaginationUtilsTestCase {
 
         pagination = new Pagination();
         pagination.setPageSize(10);
+
+        page = PaginationUtils.INSTANCE.exchange(pagination);
+        Assert.assertEquals(0, page.getFrom());
+        Assert.assertEquals(10, page.getLimit());
+
+        pagination = new Pagination();
+        pagination.setPageSize(10);
         pagination.setPageNum(2);
 
         page = PaginationUtils.INSTANCE.exchange(pagination);

--- a/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/trace.graphqls
+++ b/apm-protocol/apm-ui-protocol/src/main/resources/ui-graphql/trace.graphqls
@@ -6,6 +6,7 @@ type TraceBrief {
 
 # Trace basic info
 type BasicTrace {
+   segmentId: String!
    operationName: String!
    duration: Int!
    start: String!


### PR DESCRIPTION
Report @ 2018/03/04 23:00
Application [COLLECTOR] The topology is incorrect

* When entry span layer is MQ:
  1. Use peer id in entry span to find the instance id and application id.
  2. Make the instance id and application id to be the front instance id and front application id of the     reference metric.
  3. Do not create the application mapping metric.

* Add the segmentId into BasicTrace which belongs to trace query graphql protocol.
```
type BasicTrace {
   segmentId: String!
   operationName: String!
   duration: Int!
   start: String!
   isError: Boolean
   traceIds: [String!]!
}
```