### PR TITLE
Get the MQ server address id from reference.

### DIFF
--- a/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/service/refmetric/ServiceReferenceMetricSpanListener.java
+++ b/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/service/refmetric/ServiceReferenceMetricSpanListener.java
@@ -80,9 +80,8 @@ public class ServiceReferenceMetricSpanListener implements FirstSpanListener, En
                 serviceReferenceMetric.setFrontServiceId(reference.getParentServiceId());
 
                 if (spanDecorator.getSpanLayer().equals(SpanLayer.MQ)) {
-                    int peerId = spanDecorator.getPeerId();
-                    int applicationIdByPeerId = applicationCacheService.getApplicationIdByAddressId(peerId);
-                    int instanceIdByPeerId = instanceCacheService.getInstanceIdByAddressId(applicationIdByPeerId, peerId);
+                    int applicationIdByPeerId = applicationCacheService.getApplicationIdByAddressId(reference.getNetworkAddressId());
+                    int instanceIdByPeerId = instanceCacheService.getInstanceIdByAddressId(applicationIdByPeerId, reference.getNetworkAddressId());
                     serviceReferenceMetric.setFrontInstanceId(instanceIdByPeerId);
                     serviceReferenceMetric.setFrontApplicationId(applicationIdByPeerId);
                 } else {

--- a/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/test/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/service/SegmentBase64Printer.java
+++ b/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/test/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/service/SegmentBase64Printer.java
@@ -35,7 +35,7 @@ public class SegmentBase64Printer {
     private static final Logger LOGGER = LoggerFactory.getLogger(SegmentBase64Printer.class);
 
     public static void main(String[] args) throws InvalidProtocolBufferException {
-        String segmentBase64 = "CgwKCgIBsv/x1L2vgBsSggEQ////////////ARirnsP1niwg9Z7D9Z4sOhhIMi9KREJJL0Nvbm5lY3Rpb24vY2xvc2VKDGxvY2FsaG9zdDotMVABWAFgBHoOCgdkYi50eXBlEgNzcWx6GQoLZGIuaW5zdGFuY2USCmRhdGFTb3VyY2V6DgoMZGIuc3RhdGVtZW50GP///////////wEgAg==";
+        String segmentBase64 = "CgwKCgMXjPKUga3WgBsSvAEIARiF7Jq1nywgp+yatZ8sKlASDAoKAnPAqKD5rNaAGxgBIAIqDjEyNy4wLjAuMTo5MDkyOAJCFC9zZW5kTWVzc2FnZS97Y291bnR9UhQvc2VuZE1lc3NhZ2Uve2NvdW50fTocS2Fma2EvVHJhY2UtdG9waWMtMS9Db25zdW1lclgEYBt6GwoJbXEuYnJva2VyEg4xMjcuMC4wLjE6OTA5MnoZCghtcS50b3BpYxINVHJhY2UtdG9waWMtMRImEP///////////wEY/+uatZ8sILTsmrWfLDD///////////8BUAIYAiAD";
         byte[] binarySegment = Base64.getDecoder().decode(segmentBase64);
         TraceSegmentObject segmentObject = TraceSegmentObject.parseFrom(binarySegment);
 
@@ -72,6 +72,15 @@ public class SegmentBase64Printer {
             LOGGER.info("       reference:");
             span.getRefsList().forEach(reference -> {
                 LOGGER.info("           EntryApplicationInstanceId: {}", reference.getEntryApplicationInstanceId());
+                LOGGER.info("           EntryServiceId: {}", reference.getEntryServiceId());
+                LOGGER.info("           EntryServiceName: {}", reference.getEntryServiceName());
+                LOGGER.info("           ParentTraceSegmentId: {}", reference.getParentTraceSegmentId());
+                LOGGER.info("           ParentSpanId: {}", reference.getParentSpanId());
+                LOGGER.info("           ParentApplicationInstanceId: {}", reference.getParentApplicationInstanceId());
+                LOGGER.info("           ParentServiceId: {}", reference.getParentServiceId());
+                LOGGER.info("           ParentServiceName: {}", reference.getParentServiceName());
+                LOGGER.info("           NetworkAddressId: {}", reference.getNetworkAddressId());
+                LOGGER.info("           NetworkAddress: {}", reference.getNetworkAddress());
             });
         });
     }


### PR DESCRIPTION
Report @ 2018/03/05 19:00
* Trace [COLLECTOR] Can't query any trace data, add segmentId attribute into protocol: 
```
type BasicTrace {
   segmentId: String!
   operationName: String!
   duration: Int!
   start: String!
   isError: Boolean
   traceIds: [String!]!
}
```

* Topology [COLLECTOR] The topology is incorrect in Kafka case.
Get the MQ server address id from reference's network address id.