### PR TITLE
Make sure module provider can't find other service in prepare stage.

### DIFF
--- a/apm-collector/apm-collector-core/src/main/java/org/apache/skywalking/apm/collector/core/module/ModuleManager.java
+++ b/apm-collector/apm-collector-core/src/main/java/org/apache/skywalking/apm/collector/core/module/ModuleManager.java
@@ -16,7 +16,6 @@
  *
  */
 
-
 package org.apache.skywalking.apm.collector.core.module;
 
 import java.util.Arrays;
@@ -31,6 +30,7 @@ import java.util.ServiceLoader;
  * @author wu-sheng, peng-yongsheng
  */
 public class ModuleManager {
+    private boolean isInPrepareStage = true;
     private Map<String, Module> loadedModules = new HashMap<>();
 
     /**
@@ -60,6 +60,8 @@ public class ModuleManager {
                 }
             }
         }
+        // Finish prepare stage
+        isInPrepareStage = false;
 
         if (moduleList.size() > 0) {
             throw new ModuleNotFoundException(moduleList.toString() + " missing.");
@@ -76,9 +78,16 @@ public class ModuleManager {
     }
 
     public Module find(String moduleName) throws ModuleNotFoundRuntimeException {
+        assertPreparedStage();
         Module module = loadedModules.get(moduleName);
         if (module != null)
             return module;
         throw new ModuleNotFoundRuntimeException(moduleName + " missing.");
+    }
+
+    private void assertPreparedStage() {
+        if (isInPrepareStage) {
+            throw new AssertionError("Still in preparing stage.");
+        }
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues
#991
___
___
### New feature or improvement
- Describe the details and related test reports.

#991 brings me some thoughts, the ModuleManager allowed #find Service in prepare stage, which makes the #991. But it is hard to find out at first place, because in some JVM, it accidently works.

So I add this assert to make sure error happens every time. Such as, I invode #find in StorageModuleEsProvider#prepare method, this happens
```
Exception in thread "main" java.lang.AssertionError: Still in preparing stage.
	at org.apache.skywalking.apm.collector.core.module.ModuleManager.assertPreparedStage(ModuleManager.java:90)
	at org.apache.skywalking.apm.collector.core.module.ModuleManager.find(ModuleManager.java:81)
	at org.apache.skywalking.apm.collector.storage.es.StorageModuleEsProvider.prepare(StorageModuleEsProvider.java:184)
	at org.apache.skywalking.apm.collector.core.module.Module.prepare(Module.java:87)
	at org.apache.skywalking.apm.collector.core.module.ModuleManager.init(ModuleManager.java:57)
	at org.apache.skywalking.apm.collector.boot.CollectorBootStartUp.main(CollectorBootStartUp.java:43)
```
