### PR TITLE
Because of key issue, system env override can't be supported.

### DIFF
--- a/apm-collector/apm-collector-boot/src/main/java/org/apache/skywalking/apm/collector/boot/config/ApplicationConfigLoader.java
+++ b/apm-collector/apm-collector-boot/src/main/java/org/apache/skywalking/apm/collector/boot/config/ApplicationConfigLoader.java
@@ -133,7 +133,23 @@ public class ApplicationConfigLoader implements ConfigLoader<ApplicationConfigur
             return;
         }
         Properties providerSettings = moduleConfiguration.getProviderConfiguration(providerName);
-        providerSettings.put(settingKey, value);
+        if (!providerSettings.containsKey(settingKey)) {
+            return;
+        }
+        Object originValue = providerSettings.get(settingKey);
+        Class<?> type = originValue.getClass();
+        if (type.equals(int.class) || type.equals(Integer.class))
+            providerSettings.put(settingKey, Integer.valueOf(value));
+        else if (type.equals(String.class))
+            providerSettings.put(settingKey, value);
+        else if (type.equals(long.class) || type.equals(Long.class))
+            providerSettings.put(settingKey, Long.valueOf(value));
+        else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+            providerSettings.put(settingKey, Boolean.valueOf(value));
+        } else {
+            return;
+        }
+
         logger.info("The setting has been override by key: {}, value: {}, in {} provider of {} module through {}",
             settingKey, value, providerName, moduleName, isSystemProperty ? "System.properties" : "System.envs");
     }

--- a/apm-collector/apm-collector-boot/src/main/java/org/apache/skywalking/apm/collector/boot/config/ApplicationConfigLoader.java
+++ b/apm-collector/apm-collector-boot/src/main/java/org/apache/skywalking/apm/collector/boot/config/ApplicationConfigLoader.java
@@ -109,10 +109,6 @@ public class ApplicationConfigLoader implements ConfigLoader<ApplicationConfigur
             overrideModuleSettings(configuration, prop.getKey().toString(), prop.getValue().toString(), true);
         }
 
-        Map<String, String> envs = System.getenv();
-        for (String envKey : envs.keySet()) {
-            overrideModuleSettings(configuration, envKey, envs.get(envKey), false);
-        }
     }
 
     private void overrideModuleSettings(ApplicationConfiguration configuration, String key, String value,

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/SnifferConfigInitializer.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/SnifferConfigInitializer.java
@@ -105,14 +105,6 @@ public class SnifferConfigInitializer {
             }
         }
 
-        Map<String, String> envs = System.getenv();
-        for (String envKey : envs.keySet()) {
-            if (envKey.startsWith(ENV_KEY_PREFIX)) {
-                String realKey = envKey.substring(ENV_KEY_PREFIX.length());
-                properties.setProperty(realKey, envs.get(envKey));
-            }
-        }
-
         if (!properties.isEmpty()) {
             ConfigInitializer.initialize(properties, Config.class);
         }

--- a/docs/en/Setting-override.md
+++ b/docs/en/Setting-override.md
@@ -7,10 +7,10 @@ _Agent setting override supported since 3.2.5_
 ## What is setting override?
 In default, SkyWalking provide `agent.config` for client, and `application.yml` for server settings. 
 
-Setting override means end user can override the settings in these config file, by using system properties, or system environment variables.
+Setting override means end user can override the settings in these config file, by using system properties.
 
 ## Override priority
-System.Env > System.Properties(-D) > Config file
+System.Properties(-D) > Config file
  
 ## Override
 ### Agent
@@ -22,3 +22,17 @@ Use `skywalking.` + key in config file as system properties and envs key, to ove
   
 ### Collector
 Use key in config file as system properties and envs key, to override the value.
+
+Example:
+- Setting in `application.yml`
+```yaml
+agent_gRPC:
+  gRPC:
+    host: localhost
+    port: 11800
+```
+
+- Override port to 31200 by system property, add the following line into startup script.
+```
+-Dagent_gRPC.gRPC.port=31200
+```


### PR DESCRIPTION
Right now, in current implementation, we use `.` to separate the setting level, which is illegal in system env.

At the same time, several setting keys in agent.config and application.yml include `_`, make the levels can't be separated by `_`, by following system env traditions.

So, I have to revert the support, Now, only override by system properties is supported. Sadly.

@peng-yongsheng Maybe, later, we can discuss about changing the setting keys.