### PR TITLE
Enable the build of ServiceComb Java Chassis

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -31,11 +31,7 @@
 
     <modules>
         <module>servicecomb-java-chassis-0.x-plugin</module>
-        <!-- TODO: remove this submodule because of SNAPSHOT dependency. -->
-        <!-- After Apache ServiceComb released, we will put it back -->
-        <!--
         <module>servicecomb-java-chassis-1.x-plugin</module>
-        -->
     </modules>
     <packaging>pom</packaging>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-1.x-plugin/pom.xml
@@ -38,23 +38,10 @@
         <dependency>
             <groupId>org.apache.servicecomb</groupId>
             <artifactId>java-chassis-core</artifactId>
-            <version>1.0.0-m1-SNAPSHOT</version>
+            <version>1.0.0-m1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <!-- TODO: need to delete -->
-    <repositories>
-        <repository>
-            <id>apache-servicecomb</id>
-            <url>
-                https://repository.apache.org/content/repositories/snapshots
-            </url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
As ServiceComb Java Chassis 1.0.0-m1 is release, we should enable the build and publish the SNAPSHOT build of it.