### PR TITLE
exclude graphql generated classes in jacoco-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.9</version>
+                <configuration>
+                    <excludes>
+                        <exclude>*MethodAccess</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
in last pr , some testcases have been added ,but i found some error log when executing command `mvn test`,eg: https://travis-ci.org/apache/incubator-skywalking/builds/366804761
this will not affect the test results,but the logs looks long and some errors in it like 
```
java.lang.instrument.IllegalClassFormatException: Error while instrumenting class org/apache/skywalking/apm/collector/storage/ui/alarm/AlarmMethodAccess.
	at org.jacoco.agent.rt.internal_8ff85ea.CoverageTransformer.transform(CoverageTransformer.java:93)
	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:246)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:550)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1007)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at com.esotericsoftware.reflectasm.AccessClassLoader.defineClass(AccessClassLoader.java:98)
	at com.esotericsoftware.reflectasm.MethodAccess.get(MethodAccess.java:275)
	at com.coxautodev.graphql.tools.MethodFieldResolverDataFetcher.<init>(MethodFieldResolver.kt:126)
	at com.coxautodev.graphql.tools.MethodFieldResolver.createDataFetcher(MethodFieldResolver.kt:93)
	at com.coxautodev.graphql.tools.SchemaParser$createObject$$inlined$forEach$lambda$1.apply(SchemaParser.kt:124)
	at com.coxautodev.graphql.tools.SchemaParser$createObject$$inlined$forEach$lambda$1.apply(SchemaParser.kt:46)
	at graphql.schema.GraphQLObjectType$Builder.field(GraphQLObjectType.java:163)
	at com.coxautodev.graphql.tools.SchemaParser.createObject(SchemaParser.kt:122)
	at com.coxautodev.graphql.tools.SchemaParser.parseSchemaObjects(SchemaParser.kt:83)
	at com.coxautodev.graphql.tools.SchemaParser.makeExecutableSchema(SchemaParser.kt:107)
	at org.apache.skywalking.apm.collector.ui.jetty.handler.GraphQLHandler.<init>(GraphQLHandler.java:90)
	at org.apache.skywalking.apm.collector.ui.jetty.handler.GraphQLHandlerTest.setUp(GraphQLHandlerTest.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:369)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:275)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:239)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:160)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:373)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:334)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:119)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:407)
Caused by: java.io.IOException: Error while instrumenting class org/apache/skywalking/apm/collector/storage/ui/alarm/AlarmMethodAccess.
	at org.jacoco.agent.rt.internal_8ff85ea.core.instr.Instrumenter.instrumentError(Instrumenter.java:166)
	at org.jacoco.agent.rt.internal_8ff85ea.core.instr.Instrumenter.instrument(Instrumenter.java:117)
	at org.jacoco.agent.rt.internal_8ff85ea.CoverageTransformer.transform(CoverageTransformer.java:91)
	... 46 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: 2061
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.readLabel(ClassReader.java:2251)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.readFrameType(ClassReader.java:2231)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.readFrame(ClassReader.java:2165)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.readCode(ClassReader.java:1356)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.readMethod(ClassReader.java:1032)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.accept(ClassReader.java:708)
	at org.jacoco.agent.rt.internal_8ff85ea.asm.ClassReader.accept(ClassReader.java:521)
	at org.jacoco.agent.rt.internal_8ff85ea.core.instr.Instrumenter.instrument(Instrumenter.java:90)
	at org.jacoco.agent.rt.internal_8ff85ea.core.instr.Instrumenter.instrument(Instrumenter.java:114)
	... 47 more


...
java.lang.instrument.IllegalClassFormatException: Error while instrumenting class org/apache/skywalking/apm/collector/storage/ui/application/ApplicationMethodAccess.

...
java.lang.instrument.IllegalClassFormatException: Error while instrumenting class org/apache/skywalking/apm/collector/storage/ui/common/TopologyMethodAccess.
..

```

these classes which end with  `MethodAccess` are generated by `graphql` framework,and `jacoco` cannot instrument these classes for some reason(similar issue https://github.com/jacoco/eclemma/issues/18 )  and these classes don't need to compute their coverage. 
 
so i exclude them by adding configuration in `jacoco-maven-plugin` to solve this problem
```
<configuration>
          <excludes>
                   <exclude>*MethodAccess</exclude>
            </excludes>
 </configuration>
```
- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
