### PR TITLE
Fixed windows startup.bat script error

### DIFF
--- a/apm-dist/bin/collectorService.bat
+++ b/apm-dist/bin/collectorService.bat
@@ -25,7 +25,7 @@ set CLASSPATH=%COLLECTOR_HOME%\config;.;
 set CLASSPATH=%COLLECTOR_HOME%\collector-libs\*;%CLASSPATH%
 
 if defined JAVA_HOME (
- set _EXECJAVA="%JAVA_HOME:"=%"\bin\java
+ set _EXECJAVA="%JAVA_HOME%\bin\java"
 )
 
 if not defined JAVA_HOME (

--- a/apm-dist/bin/webappService.bat
+++ b/apm-dist/bin/webappService.bat
@@ -29,7 +29,7 @@ if exist "%WEBAPP_LOG_DIR%" (
 set LOG_FILE_LOCATION=%WEBAPP_LOG_DIR%\webapp.log
 
 if defined JAVA_HOME (
- set _EXECJAVA="%JAVA_HOME:"=%"\bin\java
+ set _EXECJAVA="%JAVA_HOME%\bin\java"
 )
 
 if not defined JAVA_HOME (


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1120 
___
### Bug fix
- Bug description.

When I ran the skywalking `startup.bat` script on Windows, there's an error occurred, my environment variable has configured Java_Home correctly.


When I ran the skywalking `startup.bat` script on Windows, there's an error occurred, my environment variable has configured Java_Home correctly.

I run the `startup.bat` using the Cmder app like:
```
G:\apache-skywalking-apm-incubating\bin
λ startup.bat
```
I got the following error:

```
错误: 找不到或无法加载主类 C:\Program Files\Java\jdk1.8.0_151\bin\java


Current directory:
G:\apache-skywalking-apm-incubating\bin

Command to be executed:
"C:\Program Files\Java\jdk1.8.0_151\bin\java.exe"  "C:\Program Files\Java\jdk1.8.0_151"\bin\java  ""-Xms256M -Xmx512M -Dcollector.logDir=G:\apache-skywalking-apm-incubating\bin\.\..\logs"" -cp "G:\apache-skywalking-apm-incubating\bin\.\..\collector-libs\*;G:\apache-skywalking-apm-incubating\bin\.\..\config;.;" org.apache.skywalking.apm.collector.boot.CollectorBootStartUp

ConEmuC: Root process was alive less than 10 sec, ExitCode=1.
Press Enter or Esc to close console...
```
and 

```
错误: 找不到或无法加载主类 C:\Program Files\Java\jdk1.8.0_151\bin\java


Current directory:
G:\apache-skywalking-apm-incubating\bin

Command to be executed:
"C:\Program Files\Java\jdk1.8.0_151\bin\java.exe"  "C:\Program Files\Java\jdk1.8.0_151"\bin\java   -jar G:\apache-skywalking-apm-incubating\bin\.\..\webapp/skywalking-webapp.jar --server.port=8080 --collector.ribbon.listOfServers=127.0.0.1:10800


ConEmuC: Root process was alive less than 10 sec, ExitCode=1.
Press Enter or Esc to close console...
```
- How to fix?
Fixed a path error.
