### PR TITLE
Fix Protocol doc Error And LogJsonReader Bug

### DIFF
--- a/apm-collector/apm-collector-agent/agent-jetty/agent-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/agent/jetty/provider/handler/reader/LogJsonReader.java
+++ b/apm-collector/apm-collector-agent/agent-jetty/agent-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/agent/jetty/provider/handler/reader/LogJsonReader.java
@@ -36,20 +36,25 @@ public class LogJsonReader implements StreamJsonReader<LogMessage> {
     @Override public LogMessage read(JsonReader reader) throws IOException {
         LogMessage.Builder builder = LogMessage.newBuilder();
 
+        reader.beginObject();
         while (reader.hasNext()) {
             switch (reader.nextName()) {
                 case TIME:
                     builder.setTime(reader.nextLong());
+                    break;
                 case LOG_DATA:
                     reader.beginArray();
                     while (reader.hasNext()) {
                         builder.addData(keyWithStringValueJsonReader.read(reader));
                     }
                     reader.endArray();
+                    break;
                 default:
                     reader.skipValue();
+                    break;
             }
         }
+        reader.endObject();
 
         return builder.build();
     }

--- a/docs/cn/Trace-Data-Protocol-CN.md
+++ b/docs/cn/Trace-Data-Protocol-CN.md
@@ -223,12 +223,12 @@ HTTP JSON服务, 属性名与gRPC对应，属性解释详见gRPC协议说明，�
             }
           ],
           "lo": [{
-                  "t": 1501858094726,
-                  "d": [{ 
+                  "ti": 1501858094726,
+                  "ld": [{ 
                           "k": "NullPointException",
                           "v": "Error Stack"
                       }]
-          }]
+             }]
         },
         {
           "si": 1,

--- a/docs/cn/Trace-Data-Protocol-CN.md
+++ b/docs/cn/Trace-Data-Protocol-CN.md
@@ -222,13 +222,13 @@ HTTP JSON服务, 属性名与gRPC对应，属性解释详见gRPC协议说明，�
               "v": "GET"
             }
           ],
-          "lo": { //LogMessage
-            "t": 1501858094726,
-            "d": [
-                "k": "NullPointException",
-                "v": "Error Stack"
-            }
-          }
+          "lo": [{
+                  "t": 1501858094726,
+                  "d": [{ 
+                          "k": "NullPointException",
+                          "v": "Error Stack"
+                      }]
+          }]
         },
         {
           "si": 1,

--- a/docs/cn/Trace-Data-Protocol-CN.md
+++ b/docs/cn/Trace-Data-Protocol-CN.md
@@ -209,7 +209,7 @@ HTTP JSON服务, 属性名与gRPC对应，属性解释详见gRPC协议说明，�
               "eii": 2, //entryApplicationInstanceId, 入口的实例编号
               "esi": 0, //entryServiceId, 入口的服务编号
               "esn": "/dubbox-case/case/dubbox-rest", //entryServiceName, 入口的服务名词
-              "rn": 0 //RefType, 调用方式（CrossProcess，CrossThread）
+              "rv": 0 //RefTypeValue, 调用方式（CrossProcess，CrossThread）
             }
           ],
           "to": [ //KeyWithStringValue

--- a/docs/en/Trace-Data-Protocol.md
+++ b/docs/en/Trace-Data-Protocol.md
@@ -186,7 +186,7 @@ Input：
               "eii": 2, //entryApplicationInstanceId
               "esi": 0, //entryServiceId
               "esn": "/dubbox-case/case/dubbox-rest", //entryServiceName
-              "rn": 0 //RefType
+              "rv": 0 //RefTypeValue
             }
           ],
           "to": [ //KeyWithStringValue

--- a/docs/en/Trace-Data-Protocol.md
+++ b/docs/en/Trace-Data-Protocol.md
@@ -200,8 +200,8 @@ Input：
             }
           ],
           "lo": [{
-                "t": 1501858094726,
-                "d": [{ 
+                "ti": 1501858094726,
+                "ld": [{ 
                         "k": "NullPointException",
                         "v": "Error Stack"
                     }]

--- a/docs/en/Trace-Data-Protocol.md
+++ b/docs/en/Trace-Data-Protocol.md
@@ -199,13 +199,13 @@ Input：
               "v": "GET"
             }
           ],
-          "lo": { //LogMessage
-            "t": 1501858094726,
-            "d": [
-                "k": "NullPointException",
-                "v": "Error Stack"
-            }
-          }
+          "lo": [{
+                "t": 1501858094726,
+                "d": [{ 
+                        "k": "NullPointException",
+                        "v": "Error Stack"
+                    }]
+           }]
         },
         {
           "si": 1,


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
I found this issue in coding the unit testcase.
Based on the definitions in

* `org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan` 
* `org.apache.skywalking.apm.agent.core.context.trace.LogDataEntity`
* `org.apache.skywalking.apm.agent.core.context.util.KeyValuePair`
* `org.apache.skywalking.apm.collector.agent.jetty.provider.handler.reader.LogJsonReader`
I fix the data structure in protocol doc
```java
case LOGS:
   reader.beginArray();
  while (reader.hasNext()) {
          builder.addLogs(logJsonReader.read(reader));
  }
  reader.endArray();
   break;
```
```java
 /**
     * Log is a concept from OpenTracing spec. https://github.com/opentracing/specification/blob/master/specification.md#log-structured-data
     */
    protected List<LogDataEntity> logs;

public class LogDataEntity {
    private long timestamp = 0;
    private List<KeyValuePair> logs;
}

public class KeyValuePair {
    private String key;
    private String value;
}
```
field definition
```java
 private static final String TIME = "ti";
    private static final String LOG_DATA = "ld";
```

And some bugs in `org.apache.skywalking.apm.collector.agent.jetty.provider.handler.reader.LogJsonReader`
* no `break` in `switch case`
* `JsonReader` should `beginObject()` and `endObject()` based on the structure of logs

- How to fix?
Update to right
___
### New feature or improvement
- Describe the details and related test reports.
