### PR TITLE
Fix data ttl keeper timer test case bug

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/test/java/org/apache/skywalking/apm/collector/storage/es/DataTTLKeeperTimerTestCase.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/test/java/org/apache/skywalking/apm/collector/storage/es/DataTTLKeeperTimerTestCase.java
@@ -77,9 +77,9 @@ public class DataTTLKeeperTimerTestCase {
         Assert.assertEquals(newDayTimeBucket, endDayTimeBucket);
 
         long startMonthTimeBucket = Whitebox.getInternalState(timeBuckets, "startMonthTimeBucket");
-        Assert.assertEquals((newDayTimeBucket) / 100, startMonthTimeBucket);
+        Assert.assertEquals(newDayTimeBucket / 100, startMonthTimeBucket);
 
         long endMonthTimeBucket = Whitebox.getInternalState(timeBuckets, "endMonthTimeBucket");
-        Assert.assertEquals((newDayTimeBucket) / 100, endMonthTimeBucket);
+        Assert.assertEquals(newDayTimeBucket / 100, endMonthTimeBucket);
     }
 }

--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/test/java/org/apache/skywalking/apm/collector/storage/es/DataTTLKeeperTimerTestCase.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/test/java/org/apache/skywalking/apm/collector/storage/es/DataTTLKeeperTimerTestCase.java
@@ -22,47 +22,64 @@ import org.apache.skywalking.apm.collector.core.util.TimeBucketUtils;
 import org.junit.*;
 import org.powermock.reflect.Whitebox;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
 /**
  * @author peng-yongsheng
  */
 public class DataTTLKeeperTimerTestCase {
 
     @Test
-    public void testConvertTimeBucket() {
+    public void testConvertTimeBucket() throws ParseException {
         DataTTLKeeperTimer timer = new DataTTLKeeperTimer(null, null, null, 8);
         DataTTLKeeperTimer.TimeBuckets timeBuckets = timer.convertTimeBucket();
 
         long minuteTimeBucket = TimeBucketUtils.INSTANCE.getMinuteTimeBucket(System.currentTimeMillis());
         long dayTimeBucket = TimeBucketUtils.INSTANCE.minuteToDay(minuteTimeBucket);
 
+        Date dayTimeBucketSource = new SimpleDateFormat("yyyyMMdd").parse(String.valueOf(dayTimeBucket));
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(dayTimeBucketSource);
+        calendar.add(Calendar.DAY_OF_MONTH, -8);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+
+        long newMinuteTimeBucket = TimeBucketUtils.INSTANCE.getMinuteTimeBucket(calendar.getTimeInMillis());
+        long newDayTimeBucket = TimeBucketUtils.INSTANCE.minuteToDay(newMinuteTimeBucket);
+
         long startSecondTimeBucket = Whitebox.getInternalState(timeBuckets, "startSecondTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 1000000, startSecondTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 1000000, startSecondTimeBucket);
 
         long endSecondTimeBucket = Whitebox.getInternalState(timeBuckets, "endSecondTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 1000000 + 235959, endSecondTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 1000000 + 235959, endSecondTimeBucket);
 
         long startMinuteTimeBucket = Whitebox.getInternalState(timeBuckets, "startMinuteTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 10000, startMinuteTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 10000, startMinuteTimeBucket);
 
         long endMinuteTimeBucket = Whitebox.getInternalState(timeBuckets, "endMinuteTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 10000 + 2359, endMinuteTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 10000 + 2359, endMinuteTimeBucket);
 
         long startHourTimeBucket = Whitebox.getInternalState(timeBuckets, "startHourTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 100, startHourTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 100, startHourTimeBucket);
 
         long endHourTimeBucket = Whitebox.getInternalState(timeBuckets, "endHourTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) * 100 + 23, endHourTimeBucket);
+        Assert.assertEquals(newDayTimeBucket * 100 + 23, endHourTimeBucket);
 
         long startDayTimeBucket = Whitebox.getInternalState(timeBuckets, "startDayTimeBucket");
-        Assert.assertEquals(dayTimeBucket - 8, startDayTimeBucket);
+        Assert.assertEquals(newDayTimeBucket, startDayTimeBucket);
 
         long endDayTimeBucket = Whitebox.getInternalState(timeBuckets, "endDayTimeBucket");
-        Assert.assertEquals(dayTimeBucket - 8, endDayTimeBucket);
+        Assert.assertEquals(newDayTimeBucket, endDayTimeBucket);
 
         long startMonthTimeBucket = Whitebox.getInternalState(timeBuckets, "startMonthTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) / 100, startMonthTimeBucket);
+        Assert.assertEquals((newDayTimeBucket) / 100, startMonthTimeBucket);
 
         long endMonthTimeBucket = Whitebox.getInternalState(timeBuckets, "endMonthTimeBucket");
-        Assert.assertEquals((dayTimeBucket - 8) / 100, endMonthTimeBucket);
+        Assert.assertEquals((newDayTimeBucket) / 100, endMonthTimeBucket);
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
when cross month ,the test will fail.so CI will failed for all.
Problem
```java
java.lang.AssertionError: 
Expected :20180493000000
Actual   :20180423000000
```
20180501 - 8 != 20180423
- How to fix?
use same logic code to make unit testcase instead of subtract 8.
___
### New feature or improvement
- Describe the details and related test reports.
