### PR TITLE
Delete buffer directory when collector restart.

### DIFF
--- a/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/component/ApplicationComponentSpanListener.java
+++ b/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/component/ApplicationComponentSpanListener.java
@@ -43,7 +43,7 @@ public class ApplicationComponentSpanListener implements EntrySpanListener, Exit
     }
 
     @Override public boolean containsPoint(Point point) {
-        return Point.Entry.equals(point) || Point.Exit.equals(point) || Point.First.equals(point);
+        return Point.Entry.equals(point) || Point.Exit.equals(point);
     }
 
     @Override

--- a/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/AnalysisSegmentParserModuleConfig.java
+++ b/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/AnalysisSegmentParserModuleConfig.java
@@ -28,6 +28,7 @@ public class AnalysisSegmentParserModuleConfig extends ModuleConfig {
     private String bufferFilePath;
     private String bufferOffsetMaxFileSize;
     private String bufferSegmentMaxFileSize;
+    private boolean bufferFileCleanWhenRestart;
 
     public String getBufferFilePath() {
         return bufferFilePath;
@@ -51,5 +52,13 @@ public class AnalysisSegmentParserModuleConfig extends ModuleConfig {
 
     public void setBufferSegmentMaxFileSize(String bufferSegmentMaxFileSize) {
         this.bufferSegmentMaxFileSize = bufferSegmentMaxFileSize;
+    }
+
+    public boolean isBufferFileCleanWhenRestart() {
+        return bufferFileCleanWhenRestart;
+    }
+
+    public void setBufferFileCleanWhenRestart(boolean bufferFileCleanWhenRestart) {
+        this.bufferFileCleanWhenRestart = bufferFileCleanWhenRestart;
     }
 }

--- a/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/buffer/BufferFileConfig.java
+++ b/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/buffer/BufferFileConfig.java
@@ -28,6 +28,7 @@ public class BufferFileConfig {
     static int BUFFER_OFFSET_MAX_FILE_SIZE = 10 * 1024 * 1024;
     static int BUFFER_SEGMENT_MAX_FILE_SIZE = 10 * 1024 * 1024;
     static String BUFFER_PATH = "../buffer/";
+    static boolean BUFFER_FILE_CLEAN_WHEN_RESTART = false;
 
     public static class Parser {
 
@@ -77,6 +78,8 @@ public class BufferFileConfig {
             } else {
                 BUFFER_SEGMENT_MAX_FILE_SIZE = 1024 * 1024;
             }
+
+            BUFFER_FILE_CLEAN_WHEN_RESTART = config.isBufferFileCleanWhenRestart();
         }
     }
 }

--- a/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/buffer/SegmentBufferManager.java
+++ b/apm-collector/apm-collector-analysis/analysis-segment-parser/segment-parser-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/segment/parser/provider/buffer/SegmentBufferManager.java
@@ -18,16 +18,11 @@
 
 package org.apache.skywalking.apm.collector.analysis.segment.parser.provider.buffer;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import org.apache.skywalking.apm.collector.core.module.ModuleManager;
-import org.apache.skywalking.apm.collector.core.util.Const;
-import org.apache.skywalking.apm.collector.core.util.StringUtils;
-import org.apache.skywalking.apm.collector.core.util.TimeBucketUtils;
+import org.apache.skywalking.apm.collector.core.util.*;
 import org.apache.skywalking.apm.network.proto.UpstreamSegment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
@@ -45,6 +40,9 @@ public enum SegmentBufferManager {
         try {
             OffsetManager.INSTANCE.initialize();
             if (new File(BufferFileConfig.BUFFER_PATH).mkdirs()) {
+                newDataFile();
+            } else if (BufferFileConfig.BUFFER_FILE_CLEAN_WHEN_RESTART) {
+                deleteFiles();
                 newDataFile();
             } else {
                 String writeFileName = OffsetManager.INSTANCE.getWriteFileName();
@@ -84,7 +82,11 @@ public enum SegmentBufferManager {
         String timeBucket = String.valueOf(TimeBucketUtils.INSTANCE.getSecondTimeBucket(System.currentTimeMillis()));
         String writeFileName = DATA_FILE_PREFIX + "_" + timeBucket + "." + Const.FILE_SUFFIX;
         File dataFile = new File(BufferFileConfig.BUFFER_PATH + writeFileName);
-        dataFile.createNewFile();
+        boolean created = dataFile.createNewFile();
+        if (!created) {
+            logger.info("The file named {} already exists.", writeFileName);
+        }
+
         OffsetManager.INSTANCE.setWriteOffset(writeFileName, 0);
         try {
             if (outputStream != null) {
@@ -94,6 +96,16 @@ public enum SegmentBufferManager {
             outputStream.getChannel().position(0);
         } catch (IOException e) {
             logger.error(e.getMessage(), e);
+        }
+    }
+
+    private void deleteFiles() {
+        File bufferDirectory = new File(BufferFileConfig.BUFFER_PATH);
+        boolean delete = bufferDirectory.delete();
+        if (delete) {
+            logger.info("Buffer directory is successfully deleted");
+        } else {
+            logger.info("Buffer directory is not deleted");
         }
     }
 

--- a/apm-collector/apm-collector-boot/src/main/resources/application.yml
+++ b/apm-collector/apm-collector-boot/src/main/resources/application.yml
@@ -54,6 +54,7 @@ analysis_segment_parser:
     bufferFilePath: ../buffer/
     bufferOffsetMaxFileSize: 10M
     bufferSegmentMaxFileSize: 500M
+    bufferFileCleanWhenRestart: true
 ui:
   jetty:
     host: localhost


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix

- Related issues
#1162 
___
### Bug fix
- Bug description.
Somebody restart collector after clean elastic search indexes. But they do not clean buffer files then they can see so many exception message in collector log files.
- How to fix?
Delete buffer directory when collector restart.
