### PR TITLE
Fix Average time zero 

### DIFF
--- a/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/component/ApplicationComponentSpanListener.java
+++ b/apm-collector/apm-collector-analysis/analysis-metric/metric-provider/src/main/java/org/apache/skywalking/apm/collector/analysis/metric/provider/worker/application/component/ApplicationComponentSpanListener.java
@@ -43,7 +43,7 @@ public class ApplicationComponentSpanListener implements EntrySpanListener, Exit
     }
 
     @Override public boolean containsPoint(Point point) {
-        return Point.Entry.equals(point) || Point.Exit.equals(point) || Point.First.equals(point);
+        return Point.Entry.equals(point) || Point.Exit.equals(point);
     }
 
     @Override

--- a/apm-collector/apm-collector-analysis/analysis-worker-model/src/main/java/org/apache/skywalking/apm/collector/analysis/worker/model/impl/AggregationWorker.java
+++ b/apm-collector/apm-collector-analysis/analysis-worker-model/src/main/java/org/apache/skywalking/apm/collector/analysis/worker/model/impl/AggregationWorker.java
@@ -82,6 +82,7 @@ public abstract class AggregationWorker<INPUT extends StreamData, OUTPUT extends
         if (mergeDataCache.containsKey(message.getId())) {
             mergeDataCache.get(message.getId()).mergeAndFormulaCalculateData(message);
         } else {
+            message.calculateFormula();
             mergeDataCache.put(message.getId(), message);
         }
         mergeDataCache.finishWriting();

--- a/apm-collector/apm-collector-core/src/main/java/org/apache/skywalking/apm/collector/core/data/AbstractData.java
+++ b/apm-collector/apm-collector-core/src/main/java/org/apache/skywalking/apm/collector/core/data/AbstractData.java
@@ -156,7 +156,7 @@ public abstract class AbstractData {
     }
 
     @SuppressWarnings("unchecked")
-    private void calculateFormula() {
+    public void calculateFormula() {
         for (int i = 0; i < stringColumns.length; i++) {
             if (nonNull(stringColumns[i].getFormulaOperation())) {
                 String stringData = (String)stringColumns[i].getFormulaOperation().operate(this);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
Fix `Slow Service` maybe zero ms.
![image](https://user-images.githubusercontent.com/11530760/39581737-d628cdd6-4f1e-11e8-8a10-60a6f39a2bc2.png)
- How to fix?
the cause is that we should invoke `calculateFormula()` method when first put `mergeDataCache `,because some attribute is calculated by other attribute which located in the `mergeDataCache `,such as `org.apache.skywalking.apm.collector.storage.table.service.ServiceReferenceMetric#getTransactionAverageDuration` ,so we should call this method.
___
### New feature or improvement
- Describe the details and related test reports.
