### PR TITLE
Fix Parent Application Instance Id is 0

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/TraceSegmentRef.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/trace/TraceSegmentRef.java
@@ -123,7 +123,6 @@ public class TraceSegmentRef {
         TraceSegmentReference.Builder refBuilder = TraceSegmentReference.newBuilder();
         if (SegmentRefType.CROSS_PROCESS.equals(type)) {
             refBuilder.setRefType(RefType.CrossProcess);
-            refBuilder.setParentApplicationInstanceId(parentApplicationInstanceId);
             if (peerId == DictionaryUtil.nullValue()) {
                 refBuilder.setNetworkAddress(peerHost);
             } else {
@@ -133,6 +132,7 @@ public class TraceSegmentRef {
             refBuilder.setRefType(RefType.CrossThread);
         }
 
+        refBuilder.setParentApplicationInstanceId(parentApplicationInstanceId);
         refBuilder.setEntryApplicationInstanceId(entryApplicationInstanceId);
         refBuilder.setParentTraceSegmentId(traceSegmentId.transform());
         refBuilder.setParentSpanId(spanId);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1174 
___
### Bug fix
- Bug description.

- How to fix?
Based on all `TraceSegmentRef` constructor has been set `parentApplicationInstanceId`
but `transform()` missed
___
### New feature or improvement
- Describe the details and related test reports.
