### PR TITLE
Docs/fix grpc dirname

### DIFF
--- a/docs/cn/How-to-build-CN.md
+++ b/docs/cn/How-to-build-CN.md
@@ -27,7 +27,7 @@
 1. 在IntelliJ Terminal中，执行`mvn compile -Dmaven.test.skip=true`进行编译
 1. 设置gRPC的自动生成代码目录，为源码目录
   - **apm-protocol/apm-network/target/generated-sources/protobuf**目录下的`grpc-java`和`java`目录
-  - **apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/protobuf**目录下的`grpc-java`和`java`目录
+  - **apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/generated-sources/protobuf**目录下的`grpc-java`和`java`目录
 
 ## 编译Resin-3， Resin-4 和 Oracle JDBC 驱动插件
 为了遵守Apache关于协议（License）的相关要求，不符合Apache相关要求的类库所对应的Plugin不会自动编译。如需编译对应的插件，

--- a/docs/en/How-to-build.md
+++ b/docs/en/How-to-build.md
@@ -24,7 +24,7 @@ This document helps people to compile and build the project in your maven and se
 1. Run `mvn compile -Dmaven.test.skip=true` to compile project and generate source codes. Because we use gRPC and protobuf.
 1. Set **Generated Source Codes** folders.
     * `grpc-java` and `java` folders in **apm-protocol/apm-network/target/generated-sources/protobuf**
-    * `grpc-java` and `java` folders in **apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/protobuf**
+    * `grpc-java` and `java` folders in **apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/generated-sources/protobuf**
 
 ## Building Resin-3, Resin-4, and OJDBC sdk plugins
 Due to license incompatibilities/restrictions these plugins under `apm-sniffer/apm-sdk-plugin/` are not built by default.


### PR DESCRIPTION
The directory should be apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/generated-sources/protobuf rather than apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/protobuf. Missing generated-sources/

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
N/A
___
### Bug fix
- Bug description.
Missing `generated-sources/` for protobuf dirname
- How to fix?
Replace `apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/protobuf` with `apm-collector/apm-collector-remote/apm-remote-grpc-provider/target/generated-sources/protobuf`

