### PR TITLE
Modify operationName search from match to match_phrase

### DIFF
--- a/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/SegmentDurationEsUIDAO.java
+++ b/apm-collector/apm-collector-storage/collector-storage-es-provider/src/main/java/org/apache/skywalking/apm/collector/storage/es/dao/ui/SegmentDurationEsUIDAO.java
@@ -73,7 +73,7 @@ public class SegmentDurationEsUIDAO extends EsDAO implements ISegmentDurationUID
             boolQueryBuilder.must().add(rangeQueryBuilder);
         }
         if (StringUtils.isNotEmpty(operationName)) {
-            mustQueryList.add(QueryBuilders.matchQuery(SegmentDurationTable.SERVICE_NAME.getName(), operationName));
+            mustQueryList.add(QueryBuilders.matchPhraseQuery(SegmentDurationTable.SERVICE_NAME.getName(), operationName));
         }
         if (CollectionUtils.isNotEmpty(segmentIds)) {
             boolQueryBuilder.must().add(QueryBuilders.termsQuery(SegmentDurationTable.SEGMENT_ID.getName(), segmentIds));


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

url
```
http://localhost:9200/segment_duration/type/_search
```
request
```
{
  "from" : 0,
  "size" : 20,
  "query" : {
    "bool" : {
      "must" : [
        {
          "range" : {
            "time_bucket" : {
              "from" : 20180509092900,
              "to" : 20180509094499
            }
          }
        },
        {
          "match" : {
            "service_name" : {
              "query" : "/wolverine/app"
            }
          }
        }
      ]
    }
  },
  "sort" : [
    {
      "start_time" : {
        "order" : "desc"
      }
    }
  ]
}
```
the result is:
```
{
    "took": 2,
    "timed_out": false,
    "_shards": {
        "total": 2,
        "successful": 2,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": 10,
        "max_score": null,
        "hits": [
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "71.154.15258302851470000",
                "_score": null,
                "_source": {
                    "duration": 709,
                    "start_time": 1525830285147,
                    "service_name": "/wolverine/app",
                    "end_time": 1525830285856,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "71.154.15258302851470000",
                    "application_id": 8
                },
                "sort": [
                    1525830285147
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.259.15258302851120000",
                "_score": null,
                "_source": {
                    "duration": 813,
                    "start_time": 1525830285112,
                    "service_name": "Async/devx.com/wolverine/app",
                    "end_time": 1525830285925,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "72.259.15258302851120000",
                    "application_id": 5
                },
                "sort": [
                    1525830285112
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.216.15258302851120004",
                "_score": null,
                "_source": {
                    "duration": 0,
                    "start_time": 1525830285112,
                    "service_name": "/wolverine/app",
                    "end_time": 1525830285112,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "72.216.15258302851120004",
                    "application_id": 5
                },
                "sort": [
                    1525830285112
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "71.153.15258302828530000",
                "_score": null,
                "_source": {
                    "duration": 2085,
                    "start_time": 1525830282853,
                    "service_name": "/wolverine/{type}/list",
                    "end_time": 1525830284938,
                    "time_bucket": 20180509094442,
                    "is_error": 0,
                    "segment_id": "71.153.15258302828530000",
                    "application_id": 8
                },
                "sort": [
                    1525830282853
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.214.15258302828350002",
                "_score": null,
                "_source": {
                    "duration": 0,
                    "start_time": 1525830282835,
                    "service_name": "/wolverine/deployments/list",
                    "end_time": 1525830282835,
                    "time_bucket": 20180509094442,
                    "is_error": 0,
                    "segment_id": "72.214.15258302828350002",
                    "application_id": 5
                },
                "sort": [
                    1525830282835
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.249.15258302828350000",
                "_score": null,
                "_source": {
                    "duration": 2105,
                    "start_time": 1525830282835,
                    "service_name": "Async/devx.com/wolverine/deployments/list",
                    "end_time": 1525830284940,
                    "time_bucket": 20180509094442,
                    "is_error": 0,
                    "segment_id": "72.249.15258302828350000",
                    "application_id": 5
                },
                "sort": [
                    1525830282835
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "71.151.15258302819340000",
                "_score": null,
                "_source": {
                    "duration": 731,
                    "start_time": 1525830281934,
                    "service_name": "/wolverine/{type}/list",
                    "end_time": 1525830282665,
                    "time_bucket": 20180509094441,
                    "is_error": 0,
                    "segment_id": "71.151.15258302819340000",
                    "application_id": 8
                },
                "sort": [
                    1525830281934
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.242.15258302818730000",
                "_score": null,
                "_source": {
                    "duration": 794,
                    "start_time": 1525830281873,
                    "service_name": "Async/devx.com/wolverine/namespaces/list",
                    "end_time": 1525830282667,
                    "time_bucket": 20180509094441,
                    "is_error": 0,
                    "segment_id": "72.242.15258302818730000",
                    "application_id": 5
                },
                "sort": [
                    1525830281873
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.215.15258302818720000",
                "_score": null,
                "_source": {
                    "duration": 1,
                    "start_time": 1525830281872,
                    "service_name": "/wolverine/namespaces/list",
                    "end_time": 1525830281873,
                    "time_bucket": 20180509094441,
                    "is_error": 0,
                    "segment_id": "72.215.15258302818720000",
                    "application_id": 5
                },
                "sort": [
                    1525830281872
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "71.155.15258302690880000",
                "_score": null,
                "_source": {
                    "duration": 2035,
                    "start_time": 1525830269129,
                    "service_name": "/wolverine/namespaces/list",
                    "end_time": 1525830271164,
                    "time_bucket": 20180509094429,
                    "is_error": 1,
                    "segment_id": "71.155.15258302690880000",
                    "application_id": 8
                },
                "sort": [
                    1525830269129
                ]
            }
        ]
    }
}
```
the problem is there are some record didn't contain `/wolverine/app`,they are some relation to `wolverine` or `app`,I think this is not end users wanted.they may want to the record which contain the `query` they set.so I change to `match_phrase`.

new request:
```
{
          "match_phrase" : {
            "service_name" : {
              "query" : "/wolverine/app"
            }
          }
        }
```
result:
```
{
    "took": 7,
    "timed_out": false,
    "_shards": {
        "total": 2,
        "successful": 2,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": 3,
        "max_score": null,
        "hits": [
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "71.154.15258302851470000",
                "_score": null,
                "_source": {
                    "duration": 709,
                    "start_time": 1525830285147,
                    "service_name": "/wolverine/app",
                    "end_time": 1525830285856,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "71.154.15258302851470000",
                    "application_id": 8
                },
                "sort": [
                    1525830285147
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.259.15258302851120000",
                "_score": null,
                "_source": {
                    "duration": 813,
                    "start_time": 1525830285112,
                    "service_name": "Async/devx.com/wolverine/app",
                    "end_time": 1525830285925,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "72.259.15258302851120000",
                    "application_id": 5
                },
                "sort": [
                    1525830285112
                ]
            },
            {
                "_index": "segment_duration",
                "_type": "type",
                "_id": "72.216.15258302851120004",
                "_score": null,
                "_source": {
                    "duration": 0,
                    "start_time": 1525830285112,
                    "service_name": "/wolverine/app",
                    "end_time": 1525830285112,
                    "time_bucket": 20180509094445,
                    "is_error": 0,
                    "segment_id": "72.216.15258302851120004",
                    "application_id": 5
                },
                "sort": [
                    1525830285112
                ]
            }
        ]
    }
}
```