### PR TITLE
Fix NPE in Okhttp plugin when connect failed

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/RealCallInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/okhttp/v3/RealCallInterceptor.java
@@ -100,12 +100,13 @@ public class RealCallInterceptor implements InstanceMethodsAroundInterceptor, In
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
         Class<?>[] argumentsTypes, Object ret) throws Throwable {
         Response response = (Response)ret;
-        int statusCode = response.code();
-
-        AbstractSpan span = ContextManager.activeSpan();
-        if (statusCode >= 400) {
-            span.errorOccurred();
-            Tags.STATUS_CODE.set(span, Integer.toString(statusCode));
+        if (response != null) {
+            int statusCode = response.code();
+            AbstractSpan span = ContextManager.activeSpan();
+            if (statusCode >= 400) {
+                span.errorOccurred();
+                Tags.STATUS_CODE.set(span, Integer.toString(statusCode));
+            }
         }
 
         ContextManager.stopSpan();


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
  when the request cannot connect the remote server, exception will be thrown in  `client.dispatcher().executed(this);` in okhttp3, so the method will return null thus will cause `afterMethodInterceptor` NPE  ,so the span cannot be correctly stop.
```java
@Override public Response execute() throws IOException {
    synchronized (this) {
      if (executed) throw new IllegalStateException("Already Executed");
      executed = true;
    }
    captureCallStackTrace();
    try {
      client.dispatcher().executed(this);
      Response result = getResponseWithInterceptorChain();
      if (result == null) throw new IOException("Canceled");
      return result;
    } finally {
      client.dispatcher().finished(this);
    }
  }
```

exception:
```
java.lang.NullPointerException
	at org.apache.skywalking.apm.plugin.okhttp.v3.RealCallInterceptor.afterMethod(RealCallInterceptor.java:103)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:105)
	at okhttp3.RealCall.execute(RealCall.java)
	at com.xxx.dockeradmin.opt.handle.HarborRestfulClient.listTags(HarborRestfulClient.java:141)
	at com.xxx.dockeradmin.rest.ReleaseResource.queryImages$original$MocrkffM(ReleaseResource.java:113)
	at com.xxx.dockeradmin.rest.ReleaseResource.queryImages$original$MocrkffM$accessor$SZQYOmMW(ReleaseResource.java)
	at com.xxx.dockeradmin.rest.ReleaseResource$auxiliary$uddrEsXs.call(Unknown Source)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:93)
	at com.xxx.dockeradmin.rest.ReleaseResource.queryImages(ReleaseResource.java)
	at com.xxx.dockeradmin.rest.ReleaseResource$$FastClassBySpringCGLIB$$89ccea1d.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:738)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:97)
	at com.xxx.dockeradmin.aspect.AuthAspect.aspectAroudHttpInvoke(AuthAspect.java:65)
	at sun.reflect.GeneratedMethodAccessor135.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:629)
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:618)
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:70)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
```
- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
