### PR TITLE
 way to solve Import-Project-Eclipse-RequireItems-Exception

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,6 @@
     * [Agent or collector version upgrade](en/FAQ/Upgrade.md)
     * [Protoc plugin fails in maven build](en/FAQ/Protoc-Plugin-Fails-When-Build.md)
     * [EnhanceRequireObjectCache class cast exception](en/FAQ/EnhanceRequireObjectCache-Cast-Exception.md)
-    * [Import Project Eclipse requireItems exception ](en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md)
+    * [Import Project Eclipse requireItems exception ](en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md) 
 
     

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,5 +47,6 @@
     * [Agent or collector version upgrade](en/FAQ/Upgrade.md)
     * [Protoc plugin fails in maven build](en/FAQ/Protoc-Plugin-Fails-When-Build.md)
     * [EnhanceRequireObjectCache class cast exception](en/FAQ/EnhanceRequireObjectCache-Cast-Exception.md)
+    * [Import Project Eclipse requireItems exception ](en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md)
 
     

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,6 @@
     * [Agent or collector version upgrade](en/FAQ/Upgrade.md)
     * [Protoc plugin fails in maven build](en/FAQ/Protoc-Plugin-Fails-When-Build.md)
     * [EnhanceRequireObjectCache class cast exception](en/FAQ/EnhanceRequireObjectCache-Cast-Exception.md)
-    * [Import Project Eclipse requireItems exception ](en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md) 
+    * [Required items could not be found, when import project into Eclipse](en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md) 
 
     

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -43,4 +43,4 @@
     * [Kafka消息消费端链路断裂](cn/FAQ/Kafka-plugin-CN.md)
     * [Protoc-Plugin Maven编译时异常](cn/FAQ/Protoc-Plugin-Fails-When-Build-CN.md)
     * [EnhanceRequireObjectCache 类转换异常](cn/FAQ/EnhanceRequireObjectCache-Cast-Exception-CN.md)
-    
+    * [skywalking导入eclipse依赖项目异常](cn/FAQ/Import-Project-Eclipse-RequireItems-Exception.md)

--- a/docs/cn/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
+++ b/docs/cn/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
@@ -1,0 +1,16 @@
+### 现象
+- 导入skywalking工程到eclipse,遇到如下异常
+- Cannot complete the install because one or more required items could not be found.
+  Software being installed: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
+  1.0.0.201705301746)
+  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
+  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
+
+### 原因
+未安装Eclipse Checkstyle Plug-in插件
+
+### 解决方法
+用这个地址下载https://sourceforge.net/projects/eclipse-cs/?source=typ_redirect，Eclipse Checkstyle Plug-in 版本号8.7.0.201801131309 插件安装就可以了。
+插件说明:
+The Eclipse Checkstyle plug-in integrates the Checkstyle Java code auditor into the Eclipse IDE. The plug-in provides real-time feedback to the user about 
+violations of rules that check for coding style and possible error prone code constructs.

--- a/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
+++ b/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
@@ -1,9 +1,11 @@
 ### Problem
 - Import skywalking project to Eclipse,Occur following errors:
-+  Software being installed: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
-+  1.0.0.201705301746)
-+  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
-+  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
+> Software being installed: Checkstyle configuration plugin for
+> M2Eclipse 1.0.0.201705301746
+> (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
+> 1.0.0.201705301746) Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746
+> (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
+> 1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
 
 ### Reason
 Haven't installed Eclipse Checkstyle Plug-in

--- a/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
+++ b/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
@@ -1,16 +1,15 @@
 ### Problem
-- import skywalking project to eclipse,below error occurs:
-- Cannot complete the install because one or more required items could not be found.
-  Software being installed: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
-  1.0.0.201705301746)
-  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
-  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
+- Import skywalking project to Eclipse,Occur following errors:
++  Software being installed: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
++  1.0.0.201705301746)
++  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
++  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
 
-### reason
-uninstall Eclipse Checkstyle Plug-in
+### Reason
+Haven't installed Eclipse Checkstyle Plug-in
 
 ### Resolve
-download the plugin by the link:https://sourceforge.net/projects/eclipse-cs/?source=typ_redirect，Eclipse Checkstyle Plug-in version:8.7.0.201801131309 slove the problem。
+Download the plugin through the link:https://sourceforge.net/projects/eclipse-cs/?source=typ_redirect，Eclipse Checkstyle Plug-in version:8.7.0.201801131309 plugin required.
 plugin notification:
 The Eclipse Checkstyle plug-in integrates the Checkstyle Java code auditor into the Eclipse IDE. The plug-in provides real-time feedback to the user about 
 violations of rules that check for coding style and possible error prone code constructs.

--- a/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
+++ b/docs/en/FAQ/Import-Project-Eclipse-RequireItems-Exception.md
@@ -1,0 +1,16 @@
+### Problem
+- import skywalking project to eclipse,below error occurs:
+- Cannot complete the install because one or more required items could not be found.
+  Software being installed: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group 
+  1.0.0.201705301746)
+  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
+  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
+
+### reason
+uninstall Eclipse Checkstyle Plug-in
+
+### Resolve
+download the plugin by the link:https://sourceforge.net/projects/eclipse-cs/?source=typ_redirect，Eclipse Checkstyle Plug-in version:8.7.0.201801131309 slove the problem。
+plugin notification:
+The Eclipse Checkstyle plug-in integrates the Checkstyle Java code auditor into the Eclipse IDE. The plug-in provides real-time feedback to the user about 
+violations of rules that check for coding style and possible error prone code constructs.


### PR DESCRIPTION
导入skywalking工程到eclipse,遇到如下异常
  Missing requirement: Checkstyle configuration plugin for M2Eclipse 1.0.0.201705301746 (com.basistech.m2e.code.quality.checkstyle.feature.feature.group  
  1.0.0.201705301746) requires 'net.sf.eclipsecs.core 5.2.0' but it could not be found
解决办法。