### PR TITLE
Update and nail org.apache.skywalking/apm-checkstyle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
                     <dependency>
                         <groupId>org.apache.skywalking</groupId>
                         <artifactId>apm-checkstyle</artifactId>
-                        <version>${project.version}</version>
+                        <version>5.0.0-beta</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
For #1244 , update and nail org.apache.skywalking/apm-checkstyle version to a release version, 5.0.0-beta for now.

We can update after 5.0.0-GA release.

@peng-yongsheng I think when you do next release. You can avoid manual change the version number before run script. Do you change this in last time?