### PR TITLE
[Collector] Crash down by OutOfMemoryError exception.

### DIFF
--- a/apm-collector/apm-collector-analysis/analysis-worker-model/src/main/java/org/apache/skywalking/apm/collector/analysis/worker/model/impl/PersistenceWorker.java
+++ b/apm-collector/apm-collector-analysis/analysis-worker-model/src/main/java/org/apache/skywalking/apm/collector/analysis/worker/model/impl/PersistenceWorker.java
@@ -20,12 +20,13 @@ package org.apache.skywalking.apm.collector.analysis.worker.model.impl;
 
 import java.util.*;
 import org.apache.skywalking.apm.collector.analysis.worker.model.base.AbstractLocalAsyncWorker;
+import org.apache.skywalking.apm.collector.configuration.ConfigurationModule;
+import org.apache.skywalking.apm.collector.configuration.service.IWorkerCacheSizeConfig;
 import org.apache.skywalking.apm.collector.core.annotations.trace.GraphComputingMetric;
 import org.apache.skywalking.apm.collector.core.cache.Collection;
 import org.apache.skywalking.apm.collector.core.cache.*;
 import org.apache.skywalking.apm.collector.core.data.StreamData;
 import org.apache.skywalking.apm.collector.core.module.ModuleManager;
-import org.apache.skywalking.apm.collector.core.util.StringUtils;
 import org.apache.skywalking.apm.collector.storage.StorageModule;
 import org.apache.skywalking.apm.collector.storage.base.dao.*;
 import org.slf4j.*;
@@ -43,12 +44,7 @@ public abstract class PersistenceWorker<INPUT_AND_OUTPUT extends StreamData, COL
     PersistenceWorker(ModuleManager moduleManager) {
         super(moduleManager);
         this.batchDAO = moduleManager.find(StorageModule.NAME).getService(IBatchDAO.class);
-
-        if (StringUtils.isNotEmpty(System.getProperty("batchSize"))) {
-            this.blockBatchPersistenceSize = Integer.valueOf(System.getProperty("batchSize"));
-        } else {
-            this.blockBatchPersistenceSize = 500000;
-        }
+        this.blockBatchPersistenceSize = moduleManager.find(ConfigurationModule.NAME).getService(IWorkerCacheSizeConfig.class).cacheSize();
     }
 
     public boolean flushAndSwitch() {

--- a/apm-collector/apm-collector-boot/src/main/resources/application.yml
+++ b/apm-collector/apm-collector-boot/src/main/resources/application.yml
@@ -92,3 +92,5 @@ configuration:
 # thermodynamic
     thermodynamicResponseTimeStep: 50
     thermodynamicCountOfResponseTimeSteps: 40
+# max collection's size of worker cache collection, setting it smaller when collector OutOfMemory crashed.
+    workerCacheMaxSize: 10000

--- a/apm-collector/apm-collector-configuration/collector-configuration-define/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModule.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-define/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModule.java
@@ -18,16 +18,7 @@
 
 package org.apache.skywalking.apm.collector.configuration;
 
-import org.apache.skywalking.apm.collector.configuration.service.IApdexThresholdService;
-import org.apache.skywalking.apm.collector.configuration.service.IApplicationAlarmRuleConfig;
-import org.apache.skywalking.apm.collector.configuration.service.IApplicationReferenceAlarmRuleConfig;
-import org.apache.skywalking.apm.collector.configuration.service.ICollectorConfig;
-import org.apache.skywalking.apm.collector.configuration.service.IComponentLibraryCatalogService;
-import org.apache.skywalking.apm.collector.configuration.service.IInstanceAlarmRuleConfig;
-import org.apache.skywalking.apm.collector.configuration.service.IInstanceReferenceAlarmRuleConfig;
-import org.apache.skywalking.apm.collector.configuration.service.IResponseTimeDistributionConfigService;
-import org.apache.skywalking.apm.collector.configuration.service.IServiceAlarmRuleConfig;
-import org.apache.skywalking.apm.collector.configuration.service.IServiceReferenceAlarmRuleConfig;
+import org.apache.skywalking.apm.collector.configuration.service.*;
 import org.apache.skywalking.apm.collector.core.module.ModuleDefine;
 
 /**
@@ -47,6 +38,6 @@ public class ConfigurationModule extends ModuleDefine {
             IApdexThresholdService.class,
             IServiceAlarmRuleConfig.class, IInstanceAlarmRuleConfig.class, IApplicationAlarmRuleConfig.class,
             IServiceReferenceAlarmRuleConfig.class, IInstanceReferenceAlarmRuleConfig.class, IApplicationReferenceAlarmRuleConfig.class,
-            IComponentLibraryCatalogService.class, IResponseTimeDistributionConfigService.class};
+            IComponentLibraryCatalogService.class, IResponseTimeDistributionConfigService.class, IWorkerCacheSizeConfig.class};
     }
 }

--- a/apm-collector/apm-collector-configuration/collector-configuration-define/src/main/java/org/apache/skywalking/apm/collector/configuration/service/IWorkerCacheSizeConfig.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-define/src/main/java/org/apache/skywalking/apm/collector/configuration/service/IWorkerCacheSizeConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.collector.configuration.service;
+
+import org.apache.skywalking.apm.collector.core.module.Service;
+
+/**
+ * @author peng-yongsheng
+ */
+public interface IWorkerCacheSizeConfig extends Service {
+    int cacheSize();
+}

--- a/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleConfig.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleConfig.java
@@ -35,6 +35,7 @@ class ConfigurationModuleConfig extends ModuleConfig {
     private int applicationAverageResponseTimeThreshold;
     private int thermodynamicResponseTimeStep;
     private int thermodynamicCountOfResponseTimeSteps;
+    private int workerCacheMaxSize;
 
     public String getNamespace() {
         return namespace;
@@ -114,5 +115,13 @@ class ConfigurationModuleConfig extends ModuleConfig {
 
     public void setThermodynamicCountOfResponseTimeSteps(int thermodynamicCountOfResponseTimeSteps) {
         this.thermodynamicCountOfResponseTimeSteps = thermodynamicCountOfResponseTimeSteps;
+    }
+
+    public int getWorkerCacheMaxSize() {
+        return workerCacheMaxSize;
+    }
+
+    public void setWorkerCacheMaxSize(int workerCacheMaxSize) {
+        this.workerCacheMaxSize = workerCacheMaxSize;
     }
 }

--- a/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleProvider.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleProvider.java
@@ -59,6 +59,8 @@ public class ConfigurationModuleProvider extends ModuleProvider {
         int thermodynamicResponseTimeStep = config.getThermodynamicResponseTimeStep() == 0 ? 50 : config.getThermodynamicResponseTimeStep();
         int thermodynamicCountOfResponseTimeSteps = config.getThermodynamicCountOfResponseTimeSteps() == 0 ? 40 : config.getThermodynamicCountOfResponseTimeSteps();
 
+        int workerCacheMaxSize = config.getWorkerCacheMaxSize() == 0 ? 10000 : config.getWorkerCacheMaxSize();
+
         this.registerServiceImplementation(ICollectorConfig.class, new CollectorConfigService(namespace));
         this.registerServiceImplementation(IComponentLibraryCatalogService.class, new ComponentLibraryCatalogService());
         this.registerServiceImplementation(IApdexThresholdService.class, new ApdexThresholdService(applicationApdexThreshold));
@@ -69,6 +71,7 @@ public class ConfigurationModuleProvider extends ModuleProvider {
         this.registerServiceImplementation(IInstanceReferenceAlarmRuleConfig.class, new InstanceReferenceAlarmRuleConfig(instanceErrorRateThreshold, instanceAverageResponseTimeThreshold));
         this.registerServiceImplementation(IApplicationReferenceAlarmRuleConfig.class, new ApplicationReferenceAlarmRuleConfig(applicationErrorRateThreshold, applicationAverageResponseTimeThreshold));
         this.registerServiceImplementation(IResponseTimeDistributionConfigService.class, new ResponseTimeDistributionConfigService(thermodynamicResponseTimeStep, thermodynamicCountOfResponseTimeSteps));
+        this.registerServiceImplementation(IWorkerCacheSizeConfig.class, new WorkerCacheSizeConfigService(workerCacheMaxSize));
     }
 
     @Override public void start() {

--- a/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/service/WorkerCacheSizeConfigService.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/service/WorkerCacheSizeConfigService.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.collector.configuration.service;
+
+/**
+ * @author peng-yongsheng
+ */
+public class WorkerCacheSizeConfigService implements IWorkerCacheSizeConfig {
+
+    private int workerCacheMaxSize;
+
+    public WorkerCacheSizeConfigService(int workerCacheMaxSize) {
+        this.workerCacheMaxSize = workerCacheMaxSize;
+    }
+
+    @Override public int cacheSize() {
+        return workerCacheMaxSize;
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1291 
___
### Bug fix
- Bug description.
Aggregate workers and persistence workers own two cache collections. One of the their use to cache the data merged by streaming data. The other one is waiting to export aggregated when persistence timer scanning. But if persistence speed can not catch streaming speed, the cache collection's size will increased too large. Collector will crash down when all the workers cached huge data.

- How to fix?
Block streaming, mandatory persistent cache data to storage then clean the cache data.