### PR TITLE
Change index page of Incubating and optional plugin documents

### DIFF
--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/README.md
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/README.md
@@ -10,7 +10,7 @@ Here is an optional plugin `apm-trace-ignore-plugin`
 ## How to configure
 There are two ways to configure ignore patterns. Settings through system env has higher priority.
  1. Set through the system environment variable,you need to add `skywalking.trace.ignore_path` to the system variables, the value is the path that you need to ignore, multiple paths should be separated by `,`
- 2. Copy`/agent/optional-plugins/apm-trace-ignore-plugin/apm-trace-ignore-plugin.config` to `/agent/config/` dir, And add settings
+ 2. Copy`/agent/optional-plugins/apm-trace-ignore-plugin/apm-trace-ignore-plugin.config` to `/agent/config/` dir, and add rules to filter traces
 ```
 trace.ignore_path=/your/path/1/**,/your/path/2/**
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@
     * [Supported middlewares, frameworks and libraries](Supported-list.md)
       * [How to disable plugins?](en/How-to-disable-plugin.md)
       * [Optional plugins](en/Optional-plugins.md)
+        * [Trace Spring beans](en/agent-optional-plugins/Spring-bean-plugins.md)
+        * [Trace Oracle and Resin](en/agent-optional-plugins/Oracle-Resin-plugins.md)
+        * [[Incubating]Filter traces through custom services](../apm-sniffer/optional-plugins/trace-ignore-plugin/README.md)
   * Advanced Features
     * [Override settings through System.properties](en/Setting-override.md)
     * [Direct uplink and disable naming discovery](en/Direct-uplink.md)
@@ -16,8 +19,7 @@
     * [Token Authentication](en/Token-auth.md)
     * [Add your own component library settings in collector](en/Component-libraries-extend.md)
   * Incubating Features
-    * [Abstract](en/Incubating/Abstract.md)
-    * [Filter traces through custom services](../apm-sniffer/optional-plugins/trace-ignore-plugin/README.md)
+    * [Why are some features in **Incubating**?](en/Incubating/Abstract.md)
   * Application Toolkit
     * [Overview](en/Applicaton-toolkit.md)
     * [Use SkyWalking OpenTracing compatible tracer](en/Opentracing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
       * [Optional plugins](en/Optional-plugins.md)
         * [Trace Spring beans](en/agent-optional-plugins/Spring-bean-plugins.md)
         * [Trace Oracle and Resin](en/agent-optional-plugins/Oracle-Resin-plugins.md)
-        * [[Incubating]Filter traces through custom services](../apm-sniffer/optional-plugins/trace-ignore-plugin/README.md)
+        * [[**Incubating**] Filter traces through custom services](../apm-sniffer/optional-plugins/trace-ignore-plugin/README.md)
   * Advanced Features
     * [Override settings through System.properties](en/Setting-override.md)
     * [Direct uplink and disable naming discovery](en/Direct-uplink.md)

--- a/docs/en/Optional-plugins.md
+++ b/docs/en/Optional-plugins.md
@@ -3,22 +3,6 @@ Optional plugins could be provided by source codes or in `optional-plugins` fold
 
 For using these plugins, you need to compile source codes by yourself, or copy the certain plugins to `/plugins`.
 
-## Spring bean plugin
-This plugin allows to trace all methods of beans in Spring context, which are annotated with
-`@Bean`, `@Service`, `@Component` and `@Repository`.
 
-- Why does this plugin optional?  
-Tracing all methods in Spring context all creates a lot of spans, which also spend more CPU, memory and network.
-Of course you want to have spans as many as possible, but please make sure your system payload can support these.
-
-## Oracle and Resin plugins
-These plugins can't be provided in Apache release because of Oracle and Resin Licenses.
-If you want to know details, please read [Apache license legal document](https://www.apache.org/legal/resolved.html)
-
-- How should we build these optional plugins in local?
-
-1. Resin 3: Download Resin 3.0.9 and place the jar at `/ci-dependencies/resin-3.0.9.jar`.
-1. Resin 4: Download Resin 4.0.41 and place the jar at `/ci-dependencies/resin-4.0.41.jar`.
-1. Oracle: Download Oracle OJDBC-14 Driver 10.2.0.4.0 and place the jar at `/ci-dependencies/ojdbc14-10.2.0.4.0.jar`.
 
 

--- a/docs/en/agent-optional-plugins/Oracle-Resin-plugins.md
+++ b/docs/en/agent-optional-plugins/Oracle-Resin-plugins.md
@@ -1,0 +1,11 @@
+## Oracle and Resin plugins
+These plugins can't be provided in Apache release because of Oracle and Resin Licenses.
+If you want to know details, please read [Apache license legal document](https://www.apache.org/legal/resolved.html)
+
+- How should we build these optional plugins in local?
+
+1. Resin 3: Download Resin 3.0.9 and place the jar at `/ci-dependencies/resin-3.0.9.jar`.
+1. Resin 4: Download Resin 4.0.41 and place the jar at `/ci-dependencies/resin-4.0.41.jar`.
+1. Oracle: Download Oracle OJDBC-14 Driver 10.2.0.4.0 and place the jar at `/ci-dependencies/ojdbc14-10.2.0.4.0.jar`.
+
+If you have troubles for finding these files, find them [here](https://github.com/OpenSkywalking/skywalking-ci-assist/tree/master/jars)

--- a/docs/en/agent-optional-plugins/Spring-bean-plugins.md
+++ b/docs/en/agent-optional-plugins/Spring-bean-plugins.md
@@ -1,0 +1,8 @@
+## Spring bean plugin
+This plugin allows to trace all methods of beans in Spring context, which are annotated with
+`@Bean`, `@Service`, `@Component` and `@Repository`.
+
+- Why does this plugin optional?  
+
+Tracing all methods in Spring context all creates a lot of spans, which also spend more CPU, memory and network.
+Of course you want to have spans as many as possible, but please make sure your system payload can support these.


### PR DESCRIPTION
Reorganize the index pages. Make users easier to find what they need.