### PR TITLE
[Collector] Mistake of error rate config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Release Notes.
 
 #### Collector Changes
   - Topology query optimization for more than 100 apps.
+  - Error rate alarm is not triggered.
   - Tolerate unsupported segments.
   - Support Integer Array, Long Array, String Array, Double Array in streaming data model.
   - Support multiple entry span and multiple service name in one segment durtaion record.

--- a/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleProvider.java
+++ b/apm-collector/apm-collector-configuration/collector-configuration-provider/src/main/java/org/apache/skywalking/apm/collector/configuration/ConfigurationModuleProvider.java
@@ -49,11 +49,11 @@ public class ConfigurationModuleProvider extends ModuleProvider {
     @Override public void prepare() throws ServiceNotProvidedException {
         String namespace = StringUtils.isNotEmpty(config.getNamespace()) ? config.getNamespace() : Const.EMPTY_STRING;
         int applicationApdexThreshold = config.getApplicationApdexThreshold() == 0 ? 2000 : config.getApplicationApdexThreshold();
-        double serviceErrorRateThreshold = config.getServiceErrorRateThreshold() == 0 ? 10.00 : config.getServiceErrorRateThreshold();
+        double serviceErrorRateThreshold = config.getServiceErrorRateThreshold() == 0 ? 0.10 : config.getServiceErrorRateThreshold() / 100;
         int serviceAverageResponseTimeThreshold = config.getServiceAverageResponseTimeThreshold() == 0 ? 2000 : config.getServiceAverageResponseTimeThreshold();
-        double instanceErrorRateThreshold = config.getInstanceErrorRateThreshold() == 0 ? 10.00 : config.getInstanceErrorRateThreshold();
+        double instanceErrorRateThreshold = config.getInstanceErrorRateThreshold() == 0 ? 0.10 : config.getInstanceErrorRateThreshold() / 100;
         int instanceAverageResponseTimeThreshold = config.getInstanceAverageResponseTimeThreshold() == 0 ? 2000 : config.getInstanceAverageResponseTimeThreshold();
-        double applicationErrorRateThreshold = config.getApplicationErrorRateThreshold() == 0 ? 10.00 : config.getApplicationErrorRateThreshold();
+        double applicationErrorRateThreshold = config.getApplicationErrorRateThreshold() == 0 ? 0.10 : config.getApplicationErrorRateThreshold() / 100;
         int applicationAverageResponseTimeThreshold = config.getApplicationAverageResponseTimeThreshold() == 0 ? 2000 : config.getApplicationAverageResponseTimeThreshold();
 
         int thermodynamicResponseTimeStep = config.getThermodynamicResponseTimeStep() == 0 ? 50 : config.getThermodynamicResponseTimeStep();


### PR DESCRIPTION
Error rate alarm is not triggered

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1410 
___
### Bug fix
- Bug description.
The unit of error rate config in application.yml is a percentage, but alarm worker not divided by 100 to determine whether the condition is met.

- How to fix?
Divided by 100 when reading configuration.