### PR TITLE
fix zipkin provider can not receive full spans data

### DIFF
--- a/apm-collector/apm-collector-thirdparty-receiver/receiver-zipkin/receiver-zipkin-provider/src/main/java/org/apache/skywalking/apm/collector/receiver/zipkin/provider/ZipkinReceiverProvider.java
+++ b/apm-collector/apm-collector-thirdparty-receiver/receiver-zipkin/receiver-zipkin-provider/src/main/java/org/apache/skywalking/apm/collector/receiver/zipkin/provider/ZipkinReceiverProvider.java
@@ -31,6 +31,7 @@ import org.apache.skywalking.apm.collector.core.module.*;
 import org.apache.skywalking.apm.collector.jetty.manager.JettyManagerModule;
 import org.apache.skywalking.apm.collector.jetty.manager.service.JettyManagerService;
 import org.apache.skywalking.apm.collector.receiver.zipkin.define.ZipkinReceiverModule;
+import org.apache.skywalking.apm.collector.receiver.zipkin.provider.handler.SpanV1JettyHandler;
 import org.apache.skywalking.apm.collector.receiver.zipkin.provider.handler.SpanV2JettyHandler;
 import org.apache.skywalking.apm.collector.receiver.zipkin.provider.transform.Zipkin2SkyWalkingTransfer;
 import org.apache.skywalking.apm.collector.server.jetty.JettyServer;
@@ -74,6 +75,7 @@ public class ZipkinReceiverProvider extends ModuleProvider {
 
         JettyManagerService managerService = getManager().find(JettyManagerModule.NAME).getService(JettyManagerService.class);
         JettyServer jettyServer = managerService.createIfAbsent(config.getHost(), config.getPort(), config.getContextPath());
+        jettyServer.addHandler(new SpanV1JettyHandler(config, registerServices));
         jettyServer.addHandler(new SpanV2JettyHandler(config, registerServices));
 
         ISegmentParseService segmentParseService = getManager().find(AnalysisSegmentParserModule.NAME).getService(ISegmentParseService.class);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
1. SpanV1JettyHandler not add to JettyServer, so zipkin client invoke to /api/v1/spans failed, retcode 405.
```
org.springframework.web.client.HttpClientErrorException: 405 HTTP method POST is not supported by this URL
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:91) ~[spring-web-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:667) ~[spring-web-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:620) ~[spring-web-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:595) ~[spring-web-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:557) ~[spring-web-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at com.alipay.sofa.tracer.boot.zipkin.sender.ZipkinRestTemplateSender.post(ZipkinRestTemplateSender.java:110) ~[classes/:na]
	at com.alipay.sofa.tracer.boot.zipkin.sender.ZipkinRestTemplateSender.sendSpans(ZipkinRestTemplateSender.java:77) ~[classes/:na]
	at zipkin.reporter.AsyncReporter$BoundedAsyncReporter.flush(AsyncReporter.java:228) [zipkin-reporter-0.6.12.jar:na]
	at zipkin.reporter.AsyncReporter$Builder.lambda$build$0(AsyncReporter.java:153) [zipkin-reporter-0.6.12.jar:na]
	at zipkin.reporter.AsyncReporter$Builder$$Lambda$1.run(Unknown Source) [zipkin-reporter-0.6.12.jar:na]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_171]
```
2. When tcp packet is divided into multiple frames, a complete packet cannot be received at one read from InputStream by SpanProcessor, Causing parsing Json failed.
```
2018-07-03 09:53:17,991 - org.apache.skywalking.apm.collector.receiver.zipkin.provider.handler.SpanV2JettyHandler -73794 [qtp1040385133-154] ERROR [] - Malformed reading List<Span> from json
java.lang.IllegalArgumentException: Malformed reading List<Span> from json
	at zipkin2.internal.JsonCodec.exceptionReading(JsonCodec.java:240) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.V1JsonSpanReader.readList(V1JsonSpanReader.java:46) ~[zipkin-2.9.1.jar:?]
	at zipkin2.codec.SpanBytesDecoder$1.decodeList(SpanBytesDecoder.java:50) ~[zipkin-2.9.1.jar:?]
	at zipkin2.codec.SpanBytesDecoder.decodeList(SpanBytesDecoder.java:151) ~[zipkin-2.9.1.jar:?]
	at zipkin2.codec.SpanBytesDecoder$1.decodeList(SpanBytesDecoder.java:63) ~[zipkin-2.9.1.jar:?]
	at org.apache.skywalking.apm.collector.receiver.zipkin.provider.handler.SpanProcessor.convert(SpanProcessor.java:45) ~[receiver-zipkin-provider-5.0.0-beta2-SNAPSHOT.jar:5.0.0-beta2-SNAPSHOT]
	at org.apache.skywalking.apm.collector.receiver.zipkin.provider.handler.SpanV1JettyHandler.doPost(SpanV1JettyHandler.java:61) [receiver-zipkin-provider-5.0.0-beta2-SNAPSHOT.jar:5.0.0-beta2-SNAPSHOT]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707) [javax.servlet-api-3.1.0.jar:3.1.0]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [javax.servlet-api-3.1.0.jar:3.1.0]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:841) [jetty-servlet-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:543) [jetty-servlet-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1239) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:481) [jetty-servlet-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1141) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.Server.handle(Server.java:564) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:320) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:251) [jetty-server-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279) [jetty-io-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:110) [jetty-io-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124) [jetty-io-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.Invocable.invokePreferred(Invocable.java:122) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.strategy.ExecutingExecutionStrategy.invoke(ExecutingExecutionStrategy.java:58) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:201) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:133) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:672) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:590) [jetty-util-9.4.2.v20170220.jar:9.4.2.v20170220]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_171]
Caused by: zipkin2.internal.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2886 path $[2].timestamp
	at zipkin2.internal.gson.stream.JsonReader.syntaxError(JsonReader.java:1568) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.gson.stream.JsonReader.checkLenient(JsonReader.java:1409) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.gson.stream.JsonReader.doPeek(JsonReader.java:593) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.gson.stream.JsonReader.peek(JsonReader.java:425) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.JsonCodec$JsonReader.peekNull(JsonCodec.java:113) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.V1JsonSpanReader.fromJson(V1JsonSpanReader.java:66) ~[zipkin-2.9.1.jar:?]
	at zipkin2.internal.V1JsonSpanReader.readList(V1JsonSpanReader.java:40) ~[zipkin-2.9.1.jar:?]
	... 30 more
```

- How to fix?
1. Modify ZipkinReceiverProvider, add one line code to add V1 handler.
2. Modify SpanProcessor, add some code to Read the data cyclically until the reading is complete.

___
### New feature or improvement
- Describe the details and related test reports.
