### PR TITLE
Update create_source_release.sh

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -72,6 +72,10 @@ tar czf ${PRODUCT_NAME}-src.tgz \
     --exclude ${PRODUCT_NAME}/.git/ --exclude ${PRODUCT_NAME}/.DS_Store/ \
     --exclude ${PRODUCT_NAME}/.github/ --exclude ${PRODUCT_NAME}/.gitignore/ \
     --exclude ${PRODUCT_NAME}/.gitmodules/ --exclude ${PRODUCT_NAME}/.travis.yml \
+    --exclude ${PRODUCT_NAME}/skywalking-ui/.git/ --exclude ${PRODUCT_NAME}/skywalking-ui/.DS_Store/ \
+    --exclude ${PRODUCT_NAME}/skywalking-ui/.github/ --exclude ${PRODUCT_NAME}/skywalking-ui/.gitignore/ \
+    --exclude ${PRODUCT_NAME}/skywalking-ui/.travis.yml/ \
+    --exclude ${PRODUCT_NAME}/apm-protocol/apm-network/src/main/proto/.git/ \
     ${PRODUCT_NAME}
 
 gpg --armor --detach-sig ${PRODUCT_NAME}-src.tgz


### PR DESCRIPTION
Exclude unnecessary files in source release. Because `.git` in `skywalking-ui` folder would cause compile failure.