### PR TITLE
Add an announcement about 6.0 has begun

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ including:
 - [**Incubating**] Support accepting other tracer data formats.
   - Zipkin JSON, Thrift, Protobuf v1 and v2 formats, powered by [OpenZipkin](https://github.com/openzipkin/zipkin) libs
   - Jaeger in [Zipkin Thrift or JSON v1/v2 formats](https://github.com/jaegertracing/jaeger#backwards-compatibility-with-zipkin)
+  
+# Announcement
+After SkyWalking 5.0.0-beta2 released, all core features have been provided. For 5 series, we are trying to make them stable from now. At the same time, we have already begun our works for 6 series, in branch `6.0`. It will be a long way to have the first alpha release for it. So if you want to take part in the challengeable works, welcome, but don't consider to use that. Please read the [6.0 documents](https://github.com/apache/incubator-skywalking/blob/6.0/docs/README.md) first.
 
 # Document
 - [Documents in English](docs/README.md)


### PR DESCRIPTION
Add an announcement for 6.0. The document has been reorganized and placed here: https://github.com/apache/incubator-skywalking/blob/6.0/docs/README.md . It is a draft only and not finished, welcome to discuss, everyone.

I will try to merge this tomorrow if no objection.

FYI all @apache/skywalking-committers 

