### PR TITLE
Make the icon font things more clear in NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,8 @@ Copyright 2017-2018 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-This product bundles icons/fonts from the ant-design project,
+This product bundles icons/fonts in skywalking-ui/public/font/iconfont folder
+from the ant-design project,
 https://github.com/ant-design/antd-init/tree/master/examples/local-iconfont
 Licensed under the MIT license, confirmed by ant-design team member.
 https://github.com/ant-design/ant-design/issues/10243

--- a/apm-dist/release-docs/NOTICE
+++ b/apm-dist/release-docs/NOTICE
@@ -4,6 +4,11 @@ Copyright 2017-2018 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+This product bundles icons/fonts from the ant-design project,
+https://github.com/ant-design/antd-init/tree/master/examples/local-iconfont
+Licensed under the MIT license, confirmed by ant-design team member.
+https://github.com/ant-design/ant-design/issues/10243
+
 ========================================================================
 
 grpc-java NOTICE
@@ -831,8 +836,3 @@ from and not be held liable to the user for any such damages as noted
 above as far as the program is concerned.
 
 ------
-
-This product bundles icons/fonts from the ant-design project,
-https://github.com/ant-design/antd-init/tree/master/examples/local-iconfont
-Licensed under the MIT license, confirmed by ant-design team member.
-https://github.com/ant-design/ant-design/issues/10243


### PR DESCRIPTION
Make the icon font things more clear in NOTICE, including where they are in our source folder. Also, move the text at the beginning of the distribution NOTICE file.