### PR TITLE
Fix #1488: Fix NPE when the targetAop class is null

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/main/java/org/apache/skywalking/apm/plugin/spring/patch/AopExpressionMatchInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/main/java/org/apache/skywalking/apm/plugin/spring/patch/AopExpressionMatchInterceptor.java
@@ -15,17 +15,15 @@
  * limitations under the License.
  */
 
-
 package org.apache.skywalking.apm.plugin.spring.patch;
-
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
 
 /**
  * {@link AopExpressionMatchInterceptor} check if the method is match the enhanced method
@@ -42,30 +40,33 @@ public class AopExpressionMatchInterceptor implements StaticMethodsAroundInterce
     }
 
     @Override
-    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes, MethodInterceptResult result) {
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+        MethodInterceptResult result) {
 
     }
 
     @Override
-    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes, Object ret) {
-        Method targetAopMethod = (Method) allArguments[1];
-        Class<?> targetAopClass = (Class<?>) allArguments[2];
-        if (EnhancedInstance.class.isAssignableFrom(targetAopClass) && isEnhancedMethod(targetAopMethod)) {
+    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+        Object ret) {
+        Method targetAopMethod = (Method)allArguments[1];
+        Class<?> targetAopClass = (Class<?>)allArguments[2];
+        if (targetAopClass != null && EnhancedInstance.class.isAssignableFrom(targetAopClass) && isEnhancedMethod(targetAopMethod)) {
             return false;
         }
         return ret;
     }
 
     @Override
-    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes, Throwable t) {
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+        Throwable t) {
 
     }
 
     private boolean isEnhancedMethod(Method targetMethod) {
         for (Method method : methods) {
             if (method.getName().equals(targetMethod.getName())
-                    && method.getReturnType().equals(targetMethod.getReturnType())
-                    && equalParamTypes(method.getParameterTypes(), targetMethod.getParameterTypes())) {
+                && method.getReturnType().equals(targetMethod.getReturnType())
+                && equalParamTypes(method.getParameterTypes(), targetMethod.getParameterTypes())) {
                 return true;
             }
         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1488 

The Javadoc show that the target class maybe null, so we add the check statement.