### PR TITLE
Update ServiceNameService.java

### DIFF
--- a/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServiceNameService.java
+++ b/apm-collector/apm-collector-ui/collector-ui-jetty-provider/src/main/java/org/apache/skywalking/apm/collector/ui/service/ServiceNameService.java
@@ -77,7 +77,7 @@ public class ServiceNameService {
 
     private long startTimeMillis() {
         int minuteMetricDataTTL = configService.minuteMetricDataTTL();
-        return System.currentTimeMillis() - minuteMetricDataTTL * 60 * 1000;
+        return System.currentTimeMillis() - minuteMetricDataTTL * 60 * 1000L;
     }
 
     public ThroughputTrend getServiceThroughputTrend(int serviceId, Step step, long startTimeBucket,


### PR DESCRIPTION
resolve the Integer overflow,convert the value to Long type

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix

- Related issues

___
### Bug fix
- Bug description.
when minuteMetricDataTTL is changed to a Big Value,the minuteMetricDataTTL*60*1000 will cause to Integer overflow
- How to fix?
convert the value to Long type
___
### New feature or improvement
- Describe the details and related test reports.
