### PR TITLE
fix bug: memory leak caused by using unique instances of HystrixCon…

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hystrix/v1/SWHystrixConcurrencyStrategyWrapper.java
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hystrix/v1/SWHystrixConcurrencyStrategyWrapper.java
@@ -20,10 +20,12 @@
 package org.apache.skywalking.apm.plugin.hystrix.v1;
 
 import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
-import java.util.concurrent.Callable;
+
 import org.apache.skywalking.apm.agent.core.conf.RuntimeContextConfiguration;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.RuntimeContextSnapshot;
+
+import java.util.concurrent.Callable;
 
 public class SWHystrixConcurrencyStrategyWrapper extends HystrixConcurrencyStrategy {
 
@@ -36,7 +38,10 @@ public class SWHystrixConcurrencyStrategyWrapper extends HystrixConcurrencyStrat
 
     @Override
     public <T> Callable<T> wrapCallable(Callable<T> callable) {
-        return new WrappedCallable<T>(ContextManager.getRuntimeContext().capture(), super.wrapCallable(callable));
+        Callable<T> delegateCallable = delegate != null
+                ? delegate.wrapCallable(callable)
+                : super.wrapCallable(callable);
+        return new WrappedCallable<T>(ContextManager.getRuntimeContext().capture(), delegateCallable);
     }
 
     static class WrappedCallable<T> implements Callable<T> {


### PR DESCRIPTION
…currencyStrategy instead of a single instance

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ * ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

#1604

___
### Bug fix
- Bug description.

app print log info: Over 100 instances of HystrixRequestVariable are being stored. This is likely the sign of a memory leak caused by using unique instances of HystrixConcurrencyStrategy instead of a single instance.

![image](https://user-images.githubusercontent.com/5206798/44790014-b9969180-abd0-11e8-81ca-b8eb8c02356d.png)


- How to fix?

create one instance of HystrixConcurrencyStrategy and save it, then get the one if needed, not new one instance every time.
___
### New feature or improvement
- Describe the details and related test reports.
