### PR TITLE
Shutdown channel and notify when service unavailable

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -138,6 +138,8 @@ public class GRPCChannelManager implements BootService, Runnable {
     public void reportError(Throwable throwable) {
         if (isNetworkError(throwable)) {
             reconnect = true;
+            this.managedChannel.shutdownNow();
+            this.notify(GRPCChannelStatus.DISCONNECT);
         }
     }
 


### PR DESCRIPTION
@ejona86 @ascrutae 

If I do managedChannel#shutdownNow, will ongoing StreamObserver(belong to this channel) do onError? If yes, I think when service is unavailable at old address/port, I should kill the old connection.

The reason I raise this is, that when SkyWalking backend deployed in k8s, reboot may mean address/port changes. I want to make sure not channel is closed permanently. Now I am doing this by `isNetworkError` exception received.

I am doing `isNetworkError` in this way
```
    private boolean isNetworkError(Throwable throwable) {
        if (throwable instanceof StatusRuntimeException) {
            StatusRuntimeException statusRuntimeException = (StatusRuntimeException)throwable;
            return statusEquals(statusRuntimeException.getStatus(),
                Status.UNAVAILABLE,
                Status.PERMISSION_DENIED,
                Status.UNAUTHENTICATED,
                Status.RESOURCE_EXHAUSTED,
                Status.UNKNOWN
            );
        }
        return false;
    }
```

@ejona86 If you have any better suggestion to do so (can't use k8s API to do service discovery:( , this is not an option in the agent ), please let me know.