### PR TITLE
Change architecture image to supported things

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The core features are following.
 - Alarm
 
 
-<img src="https://skywalkingtest.github.io/page-resources/6_overview.png"/>
+<img src="https://skywalkingtest.github.io/page-resources/6-alpha-overview.png"/>
 
 SkyWalking supports to collect telemetry (traces and metrics) data from different sources, 
 in order to provide more options


### PR DESCRIPTION
To avoid people confused about our target architecture.