### PR TITLE
Support time bucket transfer for all indicators.

### DIFF
--- a/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
+++ b/oap-server/server-alarm-plugin/src/test/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRuleTest.java
@@ -240,6 +240,18 @@ public class RunningRuleTest {
 
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public int getValue() {
             return value;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllDispatcher.java
@@ -35,6 +35,7 @@ public class AllDispatcher implements SourceDispatcher<All> {
         doAllP90(source);
         doAllP75(source);
         doAllP50(source);
+        doAllHeatmap(source);
     }
 
     private void doAllP99(All source) {
@@ -75,6 +76,14 @@ public class AllDispatcher implements SourceDispatcher<All> {
 
         indicator.setTimeBucket(source.getTimeBucket());
         indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doAllHeatmap(All source) {
+        AllHeatmapIndicator indicator = new AllHeatmapIndicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.combine(source.getLatency(), 100, 20);
         IndicatorProcess.INSTANCE.in(indicator);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
@@ -16,11 +16,9 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
+package org.apache.skywalking.oap.server.core.analysis.generated.all;
 
 import java.util.*;
-import lombok.*;
-import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -38,23 +36,17 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "service_relation_server_calls_sum", builder = ServiceRelationServerCallsSumIndicator.Builder.class)
-public class ServiceRelationServerCallsSumIndicator extends SumIndicator implements AlarmSupported {
+@StorageEntity(name = "all_heatmap", builder = AllHeatmapIndicator.Builder.class)
+public class AllHeatmapIndicator extends ThermodynamicIndicator implements AlarmSupported {
 
-    @Setter @Getter @Column(columnName = "source_service_id") private int sourceServiceId;
-    @Setter @Getter @Column(columnName = "dest_service_id") private int destServiceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
-        splitJointId += Const.ID_SPLIT + String.valueOf(sourceServiceId);
-        splitJointId += Const.ID_SPLIT + String.valueOf(destServiceId);
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
-        result = 31 * result + sourceServiceId;
-        result = 31 * result + destServiceId;
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -67,11 +59,7 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceRelationServerCallsSumIndicator indicator = (ServiceRelationServerCallsSumIndicator)obj;
-        if (sourceServiceId != indicator.sourceServiceId)
-            return false;
-        if (destServiceId != indicator.destServiceId)
-            return false;
+        AllHeatmapIndicator indicator = (AllHeatmapIndicator)obj;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -82,81 +70,84 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
 
-        remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getSourceServiceId());
-        remoteBuilder.setDataIntegers(1, getDestServiceId());
+        remoteBuilder.setDataIntegers(0, getStep());
+        remoteBuilder.setDataIntegers(1, getNumOfSteps());
+        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
 
-        setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setSourceServiceId(remoteData.getDataIntegers(0));
-        setDestServiceId(remoteData.getDataIntegers(1));
+        setStep(remoteData.getDataIntegers(0));
+        setNumOfSteps(remoteData.getDataIntegers(1));
 
+        setDetailGroup(new ArrayList<>(30));
+        remoteData.getDataIntLongPairListList().forEach(element -> {
+            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
+        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("Service_Relation_Server_Calls_Sum", Scope.ServiceRelation, sourceServiceId, destServiceId);
+        return new AlarmMeta("All_heatmap", Scope.All);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+        AllHeatmapIndicator indicator = new AllHeatmapIndicator();
         indicator.setTimeBucket(toTimeBucketInHour();
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setValue(this.getValue());
+        indicator.setStep(this.getStep());
+        indicator.setNumOfSteps(this.getNumOfSteps());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+AllHeatmapIndicator indicator = new AllHeatmapIndicator();
         indicator.setTimeBucket(toTimeBucketInDay();
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setValue(this.getValue());
+        indicator.setStep(this.getStep());
+        indicator.setNumOfSteps(this.getNumOfSteps());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toTimeBucketInMonth() {
-ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+AllHeatmapIndicator indicator = new AllHeatmapIndicator();
         indicator.setTimeBucket(toTimeBucketInHour();
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setValue(this.getValue());
+        indicator.setStep(this.getStep());
+        indicator.setNumOfSteps(this.getNumOfSteps());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceRelationServerCallsSumIndicator> {
+    public static class Builder implements StorageBuilder<AllHeatmapIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceRelationServerCallsSumIndicator storageData) {
+        @Override public Map<String, Object> data2Map(AllHeatmapIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("source_service_id", storageData.getSourceServiceId());
-            map.put("dest_service_id", storageData.getDestServiceId());
-            map.put("value", storageData.getValue());
+            map.put("step", storageData.getStep());
+            map.put("num_of_steps", storageData.getNumOfSteps());
+            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceRelationServerCallsSumIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
-            indicator.setSourceServiceId(((Number)dbMap.get("source_service_id")).intValue());
-            indicator.setDestServiceId(((Number)dbMap.get("dest_service_id")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+        @Override public AllHeatmapIndicator map2Data(Map<String, Object> dbMap) {
+            AllHeatmapIndicator indicator = new AllHeatmapIndicator();
+            indicator.setStep(((Number)dbMap.get("step")).intValue());
+            indicator.setNumOfSteps(((Number)dbMap.get("num_of_steps")).intValue());
+            indicator.setDetailGroup((List)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
@@ -99,6 +99,39 @@ public class AllP50Indicator extends P50Indicator implements AlarmSupported {
         return new AlarmMeta("All_p50", Scope.All);
     }
 
+    @Override
+    public Indicator toHour() {
+        AllP50Indicator indicator = new AllP50Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+AllP50Indicator indicator = new AllP50Indicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+AllP50Indicator indicator = new AllP50Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
     public static class Builder implements StorageBuilder<AllP50Indicator> {
 
         @Override public Map<String, Object> data2Map(AllP50Indicator storageData) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
@@ -99,6 +99,39 @@ public class AllP75Indicator extends P75Indicator implements AlarmSupported {
         return new AlarmMeta("All_p75", Scope.All);
     }
 
+    @Override
+    public Indicator toHour() {
+        AllP75Indicator indicator = new AllP75Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+AllP75Indicator indicator = new AllP75Indicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+AllP75Indicator indicator = new AllP75Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
     public static class Builder implements StorageBuilder<AllP75Indicator> {
 
         @Override public Map<String, Object> data2Map(AllP75Indicator storageData) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
@@ -99,6 +99,39 @@ public class AllP90Indicator extends P90Indicator implements AlarmSupported {
         return new AlarmMeta("All_p90", Scope.All);
     }
 
+    @Override
+    public Indicator toHour() {
+        AllP90Indicator indicator = new AllP90Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+AllP90Indicator indicator = new AllP90Indicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+AllP90Indicator indicator = new AllP90Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
     public static class Builder implements StorageBuilder<AllP90Indicator> {
 
         @Override public Map<String, Object> data2Map(AllP90Indicator storageData) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP95Indicator.java
@@ -99,6 +99,39 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return new AlarmMeta("All_p95", Scope.All);
     }
 
+    @Override
+    public Indicator toHour() {
+        AllP95Indicator indicator = new AllP95Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+AllP95Indicator indicator = new AllP95Indicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+AllP95Indicator indicator = new AllP95Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
     public static class Builder implements StorageBuilder<AllP95Indicator> {
 
         @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
@@ -99,6 +99,39 @@ public class AllP99Indicator extends P99Indicator implements AlarmSupported {
         return new AlarmMeta("All_p99", Scope.All);
     }
 
+    @Override
+    public Indicator toHour() {
+        AllP99Indicator indicator = new AllP99Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+AllP99Indicator indicator = new AllP99Indicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+AllP99Indicator indicator = new AllP99Indicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
     public static class Builder implements StorageBuilder<AllP99Indicator> {
 
         @Override public Map<String, Object> data2Map(AllP99Indicator storageData) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointAvgIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointAvgIndicator.java
@@ -103,10 +103,54 @@ public class EndpointAvgIndicator extends LongAvgIndicator implements AlarmSuppo
         setServiceId(remoteData.getDataIntegers(1));
         setServiceInstanceId(remoteData.getDataIntegers(2));
         setCount(remoteData.getDataIntegers(3));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("endpoint_Avg", Scope.Endpoint, id, serviceId, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        EndpointAvgIndicator indicator = new EndpointAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+EndpointAvgIndicator indicator = new EndpointAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+EndpointAvgIndicator indicator = new EndpointAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<EndpointAvgIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointPercentIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointPercentIndicator.java
@@ -103,10 +103,54 @@ public class EndpointPercentIndicator extends PercentIndicator implements AlarmS
         setServiceId(remoteData.getDataIntegers(1));
         setServiceInstanceId(remoteData.getDataIntegers(2));
         setPercentage(remoteData.getDataIntegers(3));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("endpoint_percent", Scope.Endpoint, id, serviceId, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<EndpointPercentIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationAvgIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationAvgIndicator.java
@@ -116,10 +116,63 @@ public class EndpointRelationAvgIndicator extends LongAvgIndicator implements Al
         setServiceInstanceId(remoteData.getDataIntegers(4));
         setChildServiceInstanceId(remoteData.getDataIntegers(5));
         setCount(remoteData.getDataIntegers(6));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("EndpointRelation_Avg", Scope.EndpointRelation, endpointId, childEndpointId, serviceId, childServiceId, serviceInstanceId, childServiceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setEndpointId(this.getEndpointId());
+        indicator.setChildEndpointId(this.getChildEndpointId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setEndpointId(this.getEndpointId());
+        indicator.setChildEndpointId(this.getChildEndpointId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setEndpointId(this.getEndpointId());
+        indicator.setChildEndpointId(this.getChildEndpointId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<EndpointRelationAvgIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceAvgIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceAvgIndicator.java
@@ -97,10 +97,48 @@ public class ServiceAvgIndicator extends LongAvgIndicator implements AlarmSuppor
 
         setId(remoteData.getDataIntegers(0));
         setCount(remoteData.getDataIntegers(1));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("Service_Avg", Scope.Service, id);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceAvgIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCallsSumIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCallsSumIndicator.java
@@ -21,14 +21,15 @@ package org.apache.skywalking.oap.server.core.analysis.generated.service;
 import java.util.*;
 import lombok.*;
 import org.apache.skywalking.oap.server.core.Const;
-import org.apache.skywalking.oap.server.core.alarm.*;
-import org.apache.skywalking.oap.server.core.analysis.indicator.SumIndicator;
+import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
+import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
+import org.apache.skywalking.oap.server.core.analysis.indicator.*;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorType;
 import org.apache.skywalking.oap.server.core.remote.annotation.StreamData;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
-import org.apache.skywalking.oap.server.core.source.Scope;
-import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
 import org.apache.skywalking.oap.server.core.storage.annotation.*;
+import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
+import org.apache.skywalking.oap.server.core.source.Scope;
 
 /**
  * This class is auto generated. Please don't change this class manually.
@@ -92,10 +93,42 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
 
 
         setId(remoteData.getDataIntegers(0));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("Service_Calls_Sum", Scope.Service, id);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceCallsSumIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceDispatcher.java
@@ -20,7 +20,7 @@ package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
 import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
-import org.apache.skywalking.oap.server.core.source.Service;
+import org.apache.skywalking.oap.server.core.source.*;
 
 /**
  * This class is auto generated. Please don't change this class manually.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceRespTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceRespTimeIndicator.java
@@ -100,10 +100,51 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
         setId(remoteData.getDataIntegers(0));
         setServiceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("ServiceInstance_RespTime", Scope.ServiceInstance, id, serviceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceInstanceRespTimeIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmcpu/InstanceJvmCpuIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmcpu/InstanceJvmCpuIndicator.java
@@ -100,10 +100,51 @@ public class InstanceJvmCpuIndicator extends DoubleAvgIndicator implements Alarm
         setId(remoteData.getDataIntegers(0));
         setServiceInstanceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("instance_jvm_cpu", Scope.ServiceInstanceJVMCPU, id, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        InstanceJvmCpuIndicator indicator = new InstanceJvmCpuIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+InstanceJvmCpuIndicator indicator = new InstanceJvmCpuIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+InstanceJvmCpuIndicator indicator = new InstanceJvmCpuIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<InstanceJvmCpuIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmYoungGcTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmYoungGcTimeIndicator.java
@@ -100,10 +100,51 @@ public class InstanceJvmYoungGcTimeIndicator extends LongAvgIndicator implements
         setId(remoteData.getDataIntegers(0));
         setServiceInstanceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("instance_jvm_young_gc_time", Scope.ServiceInstanceJVMGC, id, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        InstanceJvmYoungGcTimeIndicator indicator = new InstanceJvmYoungGcTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+InstanceJvmYoungGcTimeIndicator indicator = new InstanceJvmYoungGcTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+InstanceJvmYoungGcTimeIndicator indicator = new InstanceJvmYoungGcTimeIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<InstanceJvmYoungGcTimeIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryMaxIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryMaxIndicator.java
@@ -100,10 +100,51 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
         setId(remoteData.getDataIntegers(0));
         setServiceInstanceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("instance_jvm_memory_max", Scope.ServiceInstanceJVMMemory, id, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<InstanceJvmMemoryMaxIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemorypool/InstanceJvmMemoryPoolMaxIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemorypool/InstanceJvmMemoryPoolMaxIndicator.java
@@ -100,10 +100,51 @@ public class InstanceJvmMemoryPoolMaxIndicator extends LongAvgIndicator implemen
         setId(remoteData.getDataIntegers(0));
         setServiceInstanceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("instance_jvm_memory_pool_max", Scope.ServiceInstanceJVMMemoryPool, id, serviceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setId(this.getId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<InstanceJvmMemoryPoolMaxIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancerelation/ServiceInstanceRelationAvgIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancerelation/ServiceInstanceRelationAvgIndicator.java
@@ -110,10 +110,57 @@ public class ServiceInstanceRelationAvgIndicator extends LongAvgIndicator implem
         setSourceServiceInstanceId(remoteData.getDataIntegers(2));
         setDestServiceInstanceId(remoteData.getDataIntegers(3));
         setCount(remoteData.getDataIntegers(4));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("ServiceInstanceRelation_Avg", Scope.ServiceInstanceRelation, sourceServiceId, destServiceId, sourceServiceInstanceId, destServiceInstanceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSourceServiceInstanceId(this.getSourceServiceInstanceId());
+        indicator.setDestServiceInstanceId(this.getDestServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSourceServiceInstanceId(this.getSourceServiceInstanceId());
+        indicator.setDestServiceInstanceId(this.getDestServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSourceServiceInstanceId(this.getSourceServiceInstanceId());
+        indicator.setDestServiceInstanceId(this.getDestServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceInstanceRelationAvgIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationAvgIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationAvgIndicator.java
@@ -21,14 +21,15 @@ package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation
 import java.util.*;
 import lombok.*;
 import org.apache.skywalking.oap.server.core.Const;
-import org.apache.skywalking.oap.server.core.alarm.*;
-import org.apache.skywalking.oap.server.core.analysis.indicator.LongAvgIndicator;
+import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
+import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
+import org.apache.skywalking.oap.server.core.analysis.indicator.*;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorType;
 import org.apache.skywalking.oap.server.core.remote.annotation.StreamData;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
-import org.apache.skywalking.oap.server.core.source.Scope;
-import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
 import org.apache.skywalking.oap.server.core.storage.annotation.*;
+import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
+import org.apache.skywalking.oap.server.core.source.Scope;
 
 /**
  * This class is auto generated. Please don't change this class manually.
@@ -103,10 +104,51 @@ public class ServiceRelationAvgIndicator extends LongAvgIndicator implements Ala
         setSourceServiceId(remoteData.getDataIntegers(0));
         setDestServiceId(remoteData.getDataIntegers(1));
         setCount(remoteData.getDataIntegers(2));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("ServiceRelation_Avg", Scope.ServiceRelation, sourceServiceId, destServiceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceRelationAvgIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCallsSumIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCallsSumIndicator.java
@@ -21,14 +21,15 @@ package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation
 import java.util.*;
 import lombok.*;
 import org.apache.skywalking.oap.server.core.Const;
-import org.apache.skywalking.oap.server.core.alarm.*;
-import org.apache.skywalking.oap.server.core.analysis.indicator.SumIndicator;
+import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
+import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
+import org.apache.skywalking.oap.server.core.analysis.indicator.*;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorType;
 import org.apache.skywalking.oap.server.core.remote.annotation.StreamData;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
-import org.apache.skywalking.oap.server.core.source.Scope;
-import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
 import org.apache.skywalking.oap.server.core.storage.annotation.*;
+import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
+import org.apache.skywalking.oap.server.core.source.Scope;
 
 /**
  * This class is auto generated. Please don't change this class manually.
@@ -99,10 +100,45 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
 
         setSourceServiceId(remoteData.getDataIntegers(0));
         setDestServiceId(remoteData.getDataIntegers(1));
+
+
     }
 
     @Override public AlarmMeta getAlarmMeta() {
         return new AlarmMeta("Service_Relation_Client_Calls_Sum", Scope.ServiceRelation, sourceServiceId, destServiceId);
+    }
+
+    @Override
+    public Indicator toHour() {
+        ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toDay() {
+ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
+    }
+
+    @Override
+    public Indicator toTimeBucketInMonth() {
+ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour();
+        indicator.setSourceServiceId(this.getSourceServiceId());
+        indicator.setDestServiceId(this.getDestServiceId());
+        indicator.setValue(this.getValue());
+        indicator.setTimeBucket(this.getTimeBucket());
+        return indicator;
     }
 
     public static class Builder implements StorageBuilder<ServiceRelationClientCallsSumIndicator> {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
@@ -21,7 +21,6 @@ package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
 import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
 import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
-import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
@@ -19,8 +19,9 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.indicator.expression.EqualMatch;
 import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
+import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
+import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/Indicator.java
@@ -39,6 +39,12 @@ public abstract class Indicator extends StreamData implements StorageData {
 
     public abstract void calculate();
 
+    public abstract Indicator toHour();
+
+    public abstract Indicator toDay();
+
+    public abstract Indicator toMonth();
+
     public long toTimeBucketInHour() {
         /**
          * timeBucket in minute
@@ -70,7 +76,7 @@ public abstract class Indicator extends StreamData implements StorageData {
             return timeBucket / 1000000;
         } else if (timeBucket < 9999999999L && timeBucket > 1000000000L) {
             return timeBucket / 10000;
-        } else if (timeBucket < 99999999L  && timeBucket > 10000000L) {
+        } else if (timeBucket < 99999999L && timeBucket > 10000000L) {
             return timeBucket / 100;
         } else {
             throw new IllegalStateException("Current time bucket is not in minute dimensionality");

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/Indicator.java
@@ -18,7 +18,8 @@
 
 package org.apache.skywalking.oap.server.core.analysis.indicator;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.skywalking.oap.server.core.remote.data.StreamData;
 import org.apache.skywalking.oap.server.core.storage.StorageData;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
@@ -37,4 +38,42 @@ public abstract class Indicator extends StreamData implements StorageData {
     public abstract void combine(Indicator indicator);
 
     public abstract void calculate();
+
+    public long toTimeBucketInHour() {
+        /**
+         * timeBucket in minute
+         *  201809120511
+         * min
+         *  100000000000
+         * max
+         *  999999999999
+         */
+        if (timeBucket < 999999999999L && timeBucket > 100000000000L) {
+            return timeBucket / 100;
+        } else {
+            throw new IllegalStateException("Current time bucket is not in minute dimensionality");
+        }
+    }
+
+    public long toTimeBucketInDay() {
+        if (timeBucket < 999999999999L && timeBucket > 100000000000L) {
+            return timeBucket / 10000;
+        } else if (timeBucket < 9999999999L && timeBucket > 1000000000L) {
+            return timeBucket / 100;
+        } else {
+            throw new IllegalStateException("Current time bucket is not in minute dimensionality");
+        }
+    }
+
+    public long toTimeBucketInMonth() {
+        if (timeBucket < 999999999999L && timeBucket > 100000000000L) {
+            return timeBucket / 1000000;
+        } else if (timeBucket < 9999999999L && timeBucket > 1000000000L) {
+            return timeBucket / 10000;
+        } else if (timeBucket < 99999999L  && timeBucket > 10000000L) {
+            return timeBucket / 100;
+        } else {
+            throw new IllegalStateException("Current time bucket is not in minute dimensionality");
+        }
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceComponentIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceComponentIndicator.java
@@ -98,6 +98,33 @@ public class ServiceComponentIndicator extends Indicator {
     @Override public void calculate() {
     }
 
+    @Override public Indicator toHour() {
+        ServiceComponentIndicator indicator = new ServiceComponentIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setComponentId(this.getComponentId());
+
+        return indicator;
+    }
+
+    @Override public Indicator toDay() {
+        ServiceComponentIndicator indicator = new ServiceComponentIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setComponentId(this.getComponentId());
+
+        return indicator;
+    }
+
+    @Override public Indicator toMonth() {
+        ServiceComponentIndicator indicator = new ServiceComponentIndicator();
+        indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setComponentId(this.getComponentId());
+
+        return indicator;
+    }
+
     @Override public final void combine(Indicator indicator) {
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceMappingIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/manual/service/ServiceMappingIndicator.java
@@ -18,15 +18,18 @@
 
 package org.apache.skywalking.oap.server.core.analysis.manual.service;
 
-import java.util.*;
-import lombok.*;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.analysis.indicator.Indicator;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorType;
 import org.apache.skywalking.oap.server.core.remote.annotation.StreamData;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
-import org.apache.skywalking.oap.server.core.storage.annotation.*;
+import org.apache.skywalking.oap.server.core.storage.annotation.Column;
+import org.apache.skywalking.oap.server.core.storage.annotation.StorageEntity;
 
 /**
  * @author peng-yongsheng
@@ -96,6 +99,33 @@ public class ServiceMappingIndicator extends Indicator {
     }
 
     @Override public void calculate() {
+    }
+
+    @Override public Indicator toHour() {
+        ServiceMappingIndicator indicator = new ServiceMappingIndicator();
+        indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setMappingServiceId(this.getMappingServiceId());
+
+        return indicator;
+    }
+
+    @Override public Indicator toDay() {
+        ServiceMappingIndicator indicator = new ServiceMappingIndicator();
+        indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setMappingServiceId(this.getMappingServiceId());
+
+        return indicator;
+    }
+
+    @Override public Indicator toMonth() {
+        ServiceMappingIndicator indicator = new ServiceMappingIndicator();
+        indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setMappingServiceId(this.getMappingServiceId());
+
+        return indicator;
     }
 
     @Override public final void combine(Indicator indicator) {

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/IndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/IndicatorTest.java
@@ -94,6 +94,18 @@ public class IndicatorTest {
 
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/IndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/IndicatorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.analysis.indicator;
+
+import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author wusheng
+ */
+public class IndicatorTest {
+    @Test
+    public void testTransferToTimeBucket() {
+        IndicatorMocker mocker = new IndicatorMocker();
+
+        mocker.setTimeBucket(201809120511L);
+        Assert.assertEquals(2018091205L, mocker.toTimeBucketInHour());
+        Assert.assertEquals(20180912L, mocker.toTimeBucketInDay());
+        Assert.assertEquals(201809L, mocker.toTimeBucketInMonth());
+
+        mocker = new IndicatorMocker();
+
+        mocker.setTimeBucket(2018091205L);
+        Assert.assertEquals(20180912L, mocker.toTimeBucketInDay());
+        Assert.assertEquals(201809L, mocker.toTimeBucketInMonth());
+
+        mocker = new IndicatorMocker();
+
+        mocker.setTimeBucket(20180912L);
+        Assert.assertEquals(201809L, mocker.toTimeBucketInMonth());
+    }
+
+    @Test
+    public void testIllegalTransferToTimeBucket() {
+        IndicatorMocker mocker = new IndicatorMocker();
+        mocker.setTimeBucket(2018091205L);
+
+        boolean status = true;
+        try {
+            mocker.toTimeBucketInHour();
+        } catch (IllegalStateException e) {
+            status = false;
+        }
+        Assert.assertFalse(status);
+
+        mocker = new IndicatorMocker();
+        mocker.setTimeBucket(20180912L);
+
+        status = true;
+        try {
+            mocker.toTimeBucketInHour();
+        } catch (IllegalStateException e) {
+            status = false;
+        }
+        Assert.assertFalse(status);
+
+        status = true;
+        try {
+            mocker.toTimeBucketInDay();
+        } catch (IllegalStateException e) {
+            status = false;
+        }
+        Assert.assertFalse(status);
+    }
+
+    public class IndicatorMocker extends Indicator {
+
+        @Override public String id() {
+            return null;
+        }
+
+        @Override public void combine(Indicator indicator) {
+
+        }
+
+        @Override public void calculate() {
+
+        }
+
+        @Override public void deserialize(RemoteData remoteData) {
+
+        }
+
+        @Override public RemoteData.Builder serialize() {
+            return null;
+        }
+    }
+}

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/LongAvgIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/LongAvgIndicatorTest.java
@@ -58,6 +58,18 @@ public class LongAvgIndicatorTest {
             return null;
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/PercentIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/PercentIndicatorTest.java
@@ -73,6 +73,18 @@ public class PercentIndicatorTest {
             return null;
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/PxxIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/PxxIndicatorTest.java
@@ -103,6 +103,18 @@ public class PxxIndicatorTest {
             return null;
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/SumIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/SumIndicatorTest.java
@@ -62,6 +62,18 @@ public class SumIndicatorTest {
             return null;
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/ThermodynamicIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/ThermodynamicIndicatorTest.java
@@ -98,6 +98,18 @@ public class ThermodynamicIndicatorTest {
             return null;
         }
 
+        @Override public Indicator toHour() {
+            return null;
+        }
+
+        @Override public Indicator toDay() {
+            return null;
+        }
+
+        @Override public Indicator toMonth() {
+            return null;
+        }
+
         @Override public void deserialize(RemoteData remoteData) {
 
         }


### PR DESCRIPTION
I adjusted the OAL tool to regenerate all indicators, also change the manual indicators and test mockers. 

In the parent class, I added the following methods
```
    public abstract Indicator toHour();

    public abstract Indicator toDay();

    public abstract Indicator toMonth();
```

By using this, indicator can be transferred to another new indicator in hour/day/month dimensionalities.

The high-level dimensionality timer can aggregate indicators in minutes, and save these.