### PR TITLE
Generate all metric for official release, also new func

### DIFF
--- a/docs/en/concepts-and-designs/scope-definitions.md
+++ b/docs/en/concepts-and-designs/scope-definitions.md
@@ -61,7 +61,7 @@ Calculate the metric data if the service instance is a JVM and collected by java
 | id | Represent the unique id of the service instance, usually a number. | yes | int |
 | name |  Represent the name of the service instance. Such as `ip:port@Service Name`.  **Notice**: current native agent uses `processId@Service name` as instance name, which is useless when you want to setup a filter in aggregation. | | string|
 | serviceName | Represent the name of the service. | | string |
-| isHeap | Represent this value the memory metric values are heap or not | | bool |
+| heapStatus | Represent this value the memory metric values are heap or not | | bool |
 | init | See JVM document | | long |
 | max | See JVM document | | long |
 | used | See JVM document | | long |

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
@@ -19,14 +19,15 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.all;
 
 import java.util.*;
-import org.apache.skywalking.oap.server.core.alarm.*;
+import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
+import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorType;
 import org.apache.skywalking.oap.server.core.remote.annotation.StreamData;
 import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
-import org.apache.skywalking.oap.server.core.source.Scope;
+import org.apache.skywalking.oap.server.core.storage.annotation.*;
 import org.apache.skywalking.oap.server.core.storage.StorageBuilder;
-import org.apache.skywalking.oap.server.core.storage.annotation.StorageEntity;
+import org.apache.skywalking.oap.server.core.source.Scope;
 
 /**
  * This class is auto generated. Please don't change this class manually.
@@ -38,6 +39,7 @@ import org.apache.skywalking.oap.server.core.storage.annotation.StorageEntity;
 @StorageEntity(name = "all_heatmap", builder = AllHeatmapIndicator.Builder.class)
 public class AllHeatmapIndicator extends ThermodynamicIndicator implements AlarmSupported {
 
+
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
         return splitJointId;
@@ -48,6 +50,7 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
+
 
     @Override public int remoteHashCode() {
         int result = 17;
@@ -75,6 +78,7 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
+
         remoteBuilder.setDataIntegers(0, getStep());
         remoteBuilder.setDataIntegers(1, getNumOfSteps());
         getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
@@ -86,10 +90,11 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
 
         setTimeBucket(remoteData.getDataLongs(0));
 
+
         setStep(remoteData.getDataIntegers(0));
         setNumOfSteps(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new IntKeyLongValueArray(30));
+        setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });
@@ -97,7 +102,7 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("All_heatmap", Scope.All);
+        return new AlarmMeta("all_heatmap", Scope.All);
     }
 
     @Override
@@ -148,7 +153,7 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
             AllHeatmapIndicator indicator = new AllHeatmapIndicator();
             indicator.setStep(((Number)dbMap.get("step")).intValue());
             indicator.setNumOfSteps(((Number)dbMap.get("num_of_steps")).intValue());
-            indicator.setDetailGroup((IntKeyLongValueArray)dbMap.get("detail_group"));
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllHeatmapIndicator.java
@@ -94,7 +94,7 @@ public class AllHeatmapIndicator extends ThermodynamicIndicator implements Alarm
         setStep(remoteData.getDataIntegers(0));
         setNumOfSteps(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
@@ -94,7 +94,7 @@ public class AllP50Indicator extends P50Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP50Indicator.java
@@ -94,7 +94,7 @@ public class AllP50Indicator extends P50Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new IntKeyLongValueArray(30));
+        setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });
@@ -102,7 +102,7 @@ public class AllP50Indicator extends P50Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("All_p50", Scope.All);
+        return new AlarmMeta("all_p50", Scope.All);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class AllP50Indicator extends P50Indicator implements AlarmSupported {
             AllP50Indicator indicator = new AllP50Indicator();
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((IntKeyLongValueArray)dbMap.get("detail_group"));
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
@@ -94,7 +94,7 @@ public class AllP75Indicator extends P75Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new IntKeyLongValueArray(30));
+        setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });
@@ -102,7 +102,7 @@ public class AllP75Indicator extends P75Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("All_p75", Scope.All);
+        return new AlarmMeta("all_p75", Scope.All);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class AllP75Indicator extends P75Indicator implements AlarmSupported {
             AllP75Indicator indicator = new AllP75Indicator();
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((IntKeyLongValueArray)dbMap.get("detail_group"));
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP75Indicator.java
@@ -94,7 +94,7 @@ public class AllP75Indicator extends P75Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
@@ -94,7 +94,7 @@ public class AllP90Indicator extends P90Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new IntKeyLongValueArray(30));
+        setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });
@@ -102,7 +102,7 @@ public class AllP90Indicator extends P90Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("All_p90", Scope.All);
+        return new AlarmMeta("all_p90", Scope.All);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class AllP90Indicator extends P90Indicator implements AlarmSupported {
             AllP90Indicator indicator = new AllP90Indicator();
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((IntKeyLongValueArray)dbMap.get("detail_group"));
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP90Indicator.java
@@ -94,7 +94,7 @@ public class AllP90Indicator extends P90Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP95Indicator.java
@@ -94,7 +94,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
@@ -94,7 +94,7 @@ public class AllP99Indicator extends P99Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new IntKeyLongValueArray(30));
+        setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });
@@ -102,7 +102,7 @@ public class AllP99Indicator extends P99Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("All_p99", Scope.All);
+        return new AlarmMeta("all_p99", Scope.All);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class AllP99Indicator extends P99Indicator implements AlarmSupported {
             AllP99Indicator indicator = new AllP99Indicator();
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((IntKeyLongValueArray)dbMap.get("detail_group"));
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/all/AllP99Indicator.java
@@ -94,7 +94,7 @@ public class AllP99Indicator extends P99Indicator implements AlarmSupported {
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointDispatcher.java
@@ -31,7 +31,12 @@ public class EndpointDispatcher implements SourceDispatcher<Endpoint> {
 
     @Override public void dispatch(Endpoint source) {
         doEndpointAvg(source);
-        doEndpointPercent(source);
+        doEndpointSla(source);
+        doEndpointP99(source);
+        doEndpointP95(source);
+        doEndpointP90(source);
+        doEndpointP75(source);
+        doEndpointP50(source);
     }
 
     private void doEndpointAvg(Endpoint source) {
@@ -46,8 +51,8 @@ public class EndpointDispatcher implements SourceDispatcher<Endpoint> {
         IndicatorProcess.INSTANCE.in(indicator);
     }
 
-    private void doEndpointPercent(Endpoint source) {
-        EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+    private void doEndpointSla(Endpoint source) {
+        EndpointSlaIndicator indicator = new EndpointSlaIndicator();
 
 
         indicator.setTimeBucket(source.getTimeBucket());
@@ -55,6 +60,66 @@ public class EndpointDispatcher implements SourceDispatcher<Endpoint> {
         indicator.setServiceId(source.getServiceId());
         indicator.setServiceInstanceId(source.getServiceInstanceId());
         indicator.combine(new org.apache.skywalking.oap.server.core.analysis.indicator.expression.EqualMatch(), source.isStatus(), true);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+
+    private void doEndpointP99(Endpoint source) {
+        EndpointP99Indicator indicator = new EndpointP99Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+
+    private void doEndpointP95(Endpoint source) {
+        EndpointP95Indicator indicator = new EndpointP95Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+
+    private void doEndpointP90(Endpoint source) {
+        EndpointP90Indicator indicator = new EndpointP90Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+
+    private void doEndpointP75(Endpoint source) {
+        EndpointP75Indicator indicator = new EndpointP75Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+
+    private void doEndpointP50(Endpoint source) {
+        EndpointP50Indicator indicator = new EndpointP50Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getLatency(), 10);
         IndicatorProcess.INSTANCE.in(indicator);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP50Indicator.java
@@ -110,7 +110,7 @@ public class EndpointP50Indicator extends P50Indicator implements AlarmSupported
         setValue(remoteData.getDataIntegers(2));
         setPrecision(remoteData.getDataIntegers(3));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP50Indicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancerelation;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
 import lombok.*;
@@ -38,12 +38,12 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "serviceinstancerelation_avg", builder = ServiceInstanceRelationAvgIndicator.Builder.class)
-public class ServiceInstanceRelationAvgIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_p50", builder = EndpointP50Indicator.Builder.class)
+public class EndpointP50Indicator extends P50Indicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
-    @Setter @Getter @Column(columnName = "source_service_id")  private int sourceServiceId;
-    @Setter @Getter @Column(columnName = "destServiceId")  private int destServiceId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -73,7 +73,7 @@ public class ServiceInstanceRelationAvgIndicator extends LongAvgIndicator implem
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceInstanceRelationAvgIndicator indicator = (ServiceInstanceRelationAvgIndicator)obj;
+        EndpointP50Indicator indicator = (EndpointP50Indicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -87,14 +87,14 @@ public class ServiceInstanceRelationAvgIndicator extends LongAvgIndicator implem
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getSourceServiceId());
-        remoteBuilder.setDataIntegers(1, getDestServiceId());
-        remoteBuilder.setDataIntegers(2, getCount());
+        remoteBuilder.setDataIntegers(0, getServiceId());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getValue());
+        remoteBuilder.setDataIntegers(3, getPrecision());
+        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
@@ -102,86 +102,89 @@ public class ServiceInstanceRelationAvgIndicator extends LongAvgIndicator implem
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setSourceServiceId(remoteData.getDataIntegers(0));
-        setDestServiceId(remoteData.getDataIntegers(1));
-        setCount(remoteData.getDataIntegers(2));
+        setServiceId(remoteData.getDataIntegers(0));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(2));
+        setPrecision(remoteData.getDataIntegers(3));
 
+        setDetailGroup(new ArrayList<>(30));
+        remoteData.getDataIntLongPairListList().forEach(element -> {
+            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
+        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("ServiceInstanceRelation_Avg", Scope.ServiceInstanceRelation, entityId);
+        return new AlarmMeta("endpoint_p50", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        EndpointP50Indicator indicator = new EndpointP50Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        EndpointP50Indicator indicator = new EndpointP50Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        EndpointP50Indicator indicator = new EndpointP50Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSourceServiceId(this.getSourceServiceId());
-        indicator.setDestServiceId(this.getDestServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceInstanceRelationAvgIndicator> {
+    public static class Builder implements StorageBuilder<EndpointP50Indicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceInstanceRelationAvgIndicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointP50Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
-            map.put("source_service_id", storageData.getSourceServiceId());
-            map.put("destServiceId", storageData.getDestServiceId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
+            map.put("service_id", storageData.getServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("value", storageData.getValue());
+            map.put("precision", storageData.getPrecision());
+            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceInstanceRelationAvgIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
+        @Override public EndpointP50Indicator map2Data(Map<String, Object> dbMap) {
+            EndpointP50Indicator indicator = new EndpointP50Indicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
-            indicator.setSourceServiceId(((Number)dbMap.get("source_service_id")).intValue());
-            indicator.setDestServiceId(((Number)dbMap.get("destServiceId")).intValue());
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).intValue());
+            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP75Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,22 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_p75", builder = EndpointP75Indicator.Builder.class)
+public class EndpointP75Indicator extends P75Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +61,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +73,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        EndpointP75Indicator indicator = (EndpointP75Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,24 +85,30 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
+        remoteBuilder.setDataIntegers(0, getServiceId());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getValue());
+        remoteBuilder.setDataIntegers(3, getPrecision());
         getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceId(remoteData.getDataIntegers(0));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(2));
+        setPrecision(remoteData.getDataIntegers(3));
 
         setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
@@ -102,13 +118,16 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("endpoint_p75", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP75Indicator indicator = new EndpointP75Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +137,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP75Indicator indicator = new EndpointP75Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP75Indicator indicator = new EndpointP75Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +163,13 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<EndpointP75Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointP75Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_id", storageData.getServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +177,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public EndpointP75Indicator map2Data(Map<String, Object> dbMap) {
+            EndpointP75Indicator indicator = new EndpointP75Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP75Indicator.java
@@ -110,7 +110,7 @@ public class EndpointP75Indicator extends P75Indicator implements AlarmSupported
         setValue(remoteData.getDataIntegers(2));
         setPrecision(remoteData.getDataIntegers(3));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP90Indicator.java
@@ -110,7 +110,7 @@ public class EndpointP90Indicator extends P90Indicator implements AlarmSupported
         setValue(remoteData.getDataIntegers(2));
         setPrecision(remoteData.getDataIntegers(3));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP90Indicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.endpointrelation;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
 import lombok.*;
@@ -38,14 +38,12 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "endpointrelation_avg", builder = EndpointRelationAvgIndicator.Builder.class)
-public class EndpointRelationAvgIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_p90", builder = EndpointP90Indicator.Builder.class)
+public class EndpointP90Indicator extends P90Indicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
     @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
-    @Setter @Getter @Column(columnName = "child_service_id")  private int childServiceId;
     @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
-    @Setter @Getter @Column(columnName = "child_service_instance_id")  private int childServiceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -75,7 +73,7 @@ public class EndpointRelationAvgIndicator extends LongAvgIndicator implements Al
         if (getClass() != obj.getClass())
             return false;
 
-        EndpointRelationAvgIndicator indicator = (EndpointRelationAvgIndicator)obj;
+        EndpointP90Indicator indicator = (EndpointP90Indicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -89,16 +87,14 @@ public class EndpointRelationAvgIndicator extends LongAvgIndicator implements Al
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
         remoteBuilder.setDataIntegers(0, getServiceId());
-        remoteBuilder.setDataIntegers(1, getChildServiceId());
-        remoteBuilder.setDataIntegers(2, getServiceInstanceId());
-        remoteBuilder.setDataIntegers(3, getChildServiceInstanceId());
-        remoteBuilder.setDataIntegers(4, getCount());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getValue());
+        remoteBuilder.setDataIntegers(3, getPrecision());
+        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
@@ -106,98 +102,89 @@ public class EndpointRelationAvgIndicator extends LongAvgIndicator implements Al
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setTimeBucket(remoteData.getDataLongs(0));
 
 
         setServiceId(remoteData.getDataIntegers(0));
-        setChildServiceId(remoteData.getDataIntegers(1));
-        setServiceInstanceId(remoteData.getDataIntegers(2));
-        setChildServiceInstanceId(remoteData.getDataIntegers(3));
-        setCount(remoteData.getDataIntegers(4));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(2));
+        setPrecision(remoteData.getDataIntegers(3));
 
+        setDetailGroup(new ArrayList<>(30));
+        remoteData.getDataIntLongPairListList().forEach(element -> {
+            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
+        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("EndpointRelation_Avg", Scope.EndpointRelation, entityId);
+        return new AlarmMeta("endpoint_p90", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        EndpointP90Indicator indicator = new EndpointP90Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setChildServiceId(this.getChildServiceId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        EndpointP90Indicator indicator = new EndpointP90Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setChildServiceId(this.getChildServiceId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        EndpointP90Indicator indicator = new EndpointP90Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setChildServiceId(this.getChildServiceId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<EndpointRelationAvgIndicator> {
+    public static class Builder implements StorageBuilder<EndpointP90Indicator> {
 
-        @Override public Map<String, Object> data2Map(EndpointRelationAvgIndicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointP90Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
             map.put("service_id", storageData.getServiceId());
-            map.put("child_service_id", storageData.getChildServiceId());
             map.put("service_instance_id", storageData.getServiceInstanceId());
-            map.put("child_service_instance_id", storageData.getChildServiceInstanceId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
+            map.put("precision", storageData.getPrecision());
+            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public EndpointRelationAvgIndicator map2Data(Map<String, Object> dbMap) {
-            EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+        @Override public EndpointP90Indicator map2Data(Map<String, Object> dbMap) {
+            EndpointP90Indicator indicator = new EndpointP90Indicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
-            indicator.setChildServiceId(((Number)dbMap.get("child_service_id")).intValue());
             indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
-            indicator.setChildServiceInstanceId(((Number)dbMap.get("child_service_instance_id")).intValue());
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setValue(((Number)dbMap.get("value")).intValue());
+            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP95Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,22 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_p95", builder = EndpointP95Indicator.Builder.class)
+public class EndpointP95Indicator extends P95Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +61,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +73,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        EndpointP95Indicator indicator = (EndpointP95Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,24 +85,30 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
+        remoteBuilder.setDataIntegers(0, getServiceId());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getValue());
+        remoteBuilder.setDataIntegers(3, getPrecision());
         getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceId(remoteData.getDataIntegers(0));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(2));
+        setPrecision(remoteData.getDataIntegers(3));
 
         setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
@@ -102,13 +118,16 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("endpoint_p95", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP95Indicator indicator = new EndpointP95Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +137,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP95Indicator indicator = new EndpointP95Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP95Indicator indicator = new EndpointP95Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +163,13 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<EndpointP95Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointP95Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_id", storageData.getServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +177,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public EndpointP95Indicator map2Data(Map<String, Object> dbMap) {
+            EndpointP95Indicator indicator = new EndpointP95Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP95Indicator.java
@@ -110,7 +110,7 @@ public class EndpointP95Indicator extends P95Indicator implements AlarmSupported
         setValue(remoteData.getDataIntegers(2));
         setPrecision(remoteData.getDataIntegers(3));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP99Indicator.java
@@ -110,7 +110,7 @@ public class EndpointP99Indicator extends P99Indicator implements AlarmSupported
         setValue(remoteData.getDataIntegers(2));
         setPrecision(remoteData.getDataIntegers(3));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointP99Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,22 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_p99", builder = EndpointP99Indicator.Builder.class)
+public class EndpointP99Indicator extends P99Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +61,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +73,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        EndpointP99Indicator indicator = (EndpointP99Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,24 +85,30 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
+        remoteBuilder.setDataIntegers(0, getServiceId());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getValue());
+        remoteBuilder.setDataIntegers(3, getPrecision());
         getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceId(remoteData.getDataIntegers(0));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(2));
+        setPrecision(remoteData.getDataIntegers(3));
 
         setDetailGroup(new ArrayList<>(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
@@ -102,13 +118,16 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("endpoint_p99", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP99Indicator indicator = new EndpointP99Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +137,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP99Indicator indicator = new EndpointP99Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        EndpointP99Indicator indicator = new EndpointP99Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +163,13 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<EndpointP99Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointP99Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_id", storageData.getServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +177,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public EndpointP99Indicator map2Data(Map<String, Object> dbMap) {
+            EndpointP99Indicator indicator = new EndpointP99Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointSlaIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpoint/EndpointSlaIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstance;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
 
 import java.util.*;
 import lombok.*;
@@ -38,11 +38,12 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "serviceinstance_resp_time", builder = ServiceInstanceRespTimeIndicator.Builder.class)
-public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_sla", builder = EndpointSlaIndicator.Builder.class)
+public class EndpointSlaIndicator extends PercentIndicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
     @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -72,7 +73,7 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceInstanceRespTimeIndicator indicator = (ServiceInstanceRespTimeIndicator)obj;
+        EndpointSlaIndicator indicator = (EndpointSlaIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -86,13 +87,14 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(0, getTotal());
+        remoteBuilder.setDataLongs(1, getMatch());
         remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
         remoteBuilder.setDataIntegers(0, getServiceId());
-        remoteBuilder.setDataIntegers(1, getCount());
+        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(2, getPercentage());
 
         return remoteBuilder;
     }
@@ -100,80 +102,86 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(0));
+        setMatch(remoteData.getDataLongs(1));
         setTimeBucket(remoteData.getDataLongs(2));
 
 
         setServiceId(remoteData.getDataIntegers(0));
-        setCount(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(1));
+        setPercentage(remoteData.getDataIntegers(2));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("serviceInstance_resp_time", Scope.ServiceInstance, entityId);
+        return new AlarmMeta("endpoint_sla", Scope.Endpoint, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointSlaIndicator indicator = new EndpointSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointSlaIndicator indicator = new EndpointSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointSlaIndicator indicator = new EndpointSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceInstanceRespTimeIndicator> {
+    public static class Builder implements StorageBuilder<EndpointSlaIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceInstanceRespTimeIndicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointSlaIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
             map.put("service_id", storageData.getServiceId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
-            map.put("value", storageData.getValue());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("total", storageData.getTotal());
+            map.put("percentage", storageData.getPercentage());
+            map.put("match", storageData.getMatch());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceInstanceRespTimeIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        @Override public EndpointSlaIndicator map2Data(Map<String, Object> dbMap) {
+            EndpointSlaIndicator indicator = new EndpointSlaIndicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
+            indicator.setPercentage(((Number)dbMap.get("percentage")).intValue());
+            indicator.setMatch(((Number)dbMap.get("match")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationCpmIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.service;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpointrelation;
 
 import java.util.*;
 import lombok.*;
@@ -38,10 +38,14 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "service_calls_sum", builder = ServiceCallsSumIndicator.Builder.class)
-public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_relation_cpm", builder = EndpointRelationCpmIndicator.Builder.class)
+public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "child_service_id")  private int childServiceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
+    @Setter @Getter @Column(columnName = "child_service_instance_id")  private int childServiceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -71,7 +75,7 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceCallsSumIndicator indicator = (ServiceCallsSumIndicator)obj;
+        EndpointRelationCpmIndicator indicator = (EndpointRelationCpmIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -89,6 +93,10 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
         remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
+        remoteBuilder.setDataIntegers(0, getServiceId());
+        remoteBuilder.setDataIntegers(1, getChildServiceId());
+        remoteBuilder.setDataIntegers(2, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(3, getChildServiceInstanceId());
 
         return remoteBuilder;
     }
@@ -100,19 +108,27 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
         setTimeBucket(remoteData.getDataLongs(1));
 
 
+        setServiceId(remoteData.getDataIntegers(0));
+        setChildServiceId(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(2));
+        setChildServiceInstanceId(remoteData.getDataIntegers(3));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("Service_Calls_Sum", Scope.Service, entityId);
+        return new AlarmMeta("endpoint_relation_cpm", Scope.EndpointRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        EndpointRelationCpmIndicator indicator = new EndpointRelationCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -120,9 +136,13 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
 
     @Override
     public Indicator toDay() {
-        ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        EndpointRelationCpmIndicator indicator = new EndpointRelationCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -130,27 +150,39 @@ public class ServiceCallsSumIndicator extends SumIndicator implements AlarmSuppo
 
     @Override
     public Indicator toMonth() {
-        ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        EndpointRelationCpmIndicator indicator = new EndpointRelationCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceCallsSumIndicator> {
+    public static class Builder implements StorageBuilder<EndpointRelationCpmIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceCallsSumIndicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointRelationCpmIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
+            map.put("service_id", storageData.getServiceId());
+            map.put("child_service_id", storageData.getChildServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("child_service_instance_id", storageData.getChildServiceInstanceId());
             map.put("value", storageData.getValue());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceCallsSumIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+        @Override public EndpointRelationCpmIndicator map2Data(Map<String, Object> dbMap) {
+            EndpointRelationCpmIndicator indicator = new EndpointRelationCpmIndicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setChildServiceId(((Number)dbMap.get("child_service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setChildServiceInstanceId(((Number)dbMap.get("child_service_instance_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationCpmIndicator.java
@@ -90,7 +90,8 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
         remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(1, getTotal());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
         remoteBuilder.setDataIntegers(0, getServiceId());
@@ -105,7 +106,8 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
         setEntityId(remoteData.getDataStrings(0));
 
         setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
         setServiceId(remoteData.getDataIntegers(0));
@@ -130,6 +132,7 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
         indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -144,6 +147,7 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
         indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -158,6 +162,7 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
         indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -172,6 +177,7 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
             map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("child_service_instance_id", storageData.getChildServiceInstanceId());
             map.put("value", storageData.getValue());
+            map.put("total", storageData.getTotal());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
@@ -184,6 +190,7 @@ public class EndpointRelationCpmIndicator extends CPMIndicator implements AlarmS
             indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
             indicator.setChildServiceInstanceId(((Number)dbMap.get("child_service_instance_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationDispatcher.java
@@ -19,7 +19,6 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.endpointrelation;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**
@@ -30,12 +29,32 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class EndpointRelationDispatcher implements SourceDispatcher<EndpointRelation> {
 
     @Override public void dispatch(EndpointRelation source) {
-        doEndpointRelationAvg(source);
+        doEndpointRelationCpm(source);
+        doEndpointRelationRespTime(source);
     }
 
-    private void doEndpointRelationAvg(EndpointRelation source) {
-        EndpointRelationAvgIndicator indicator = new EndpointRelationAvgIndicator();
+    private void doEndpointRelationCpm(EndpointRelation source) {
+        EndpointRelationCpmIndicator indicator = new EndpointRelationCpmIndicator();
 
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.SERVER).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.setChildServiceId(source.getChildServiceId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(source.getChildServiceInstanceId());
+        indicator.combine(1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doEndpointRelationRespTime(EndpointRelation source) {
+        EndpointRelationRespTimeIndicator indicator = new EndpointRelationRespTimeIndicator();
+
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.SERVER).match()) {
+            return;
+        }
 
         indicator.setTimeBucket(source.getTimeBucket());
         indicator.setEntityId(source.getEntityId());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationDispatcher.java
@@ -19,6 +19,8 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.endpointrelation;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
+import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
+import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationRespTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/endpointrelation/EndpointRelationRespTimeIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstance;
+package org.apache.skywalking.oap.server.core.analysis.generated.endpointrelation;
 
 import java.util.*;
 import lombok.*;
@@ -38,11 +38,14 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "serviceinstance_resp_time", builder = ServiceInstanceRespTimeIndicator.Builder.class)
-public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "endpoint_relation_resp_time", builder = EndpointRelationRespTimeIndicator.Builder.class)
+public class EndpointRelationRespTimeIndicator extends LongAvgIndicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
     @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
+    @Setter @Getter @Column(columnName = "child_service_id")  private int childServiceId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
+    @Setter @Getter @Column(columnName = "child_service_instance_id")  private int childServiceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -72,7 +75,7 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceInstanceRespTimeIndicator indicator = (ServiceInstanceRespTimeIndicator)obj;
+        EndpointRelationRespTimeIndicator indicator = (EndpointRelationRespTimeIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -92,7 +95,10 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
 
 
         remoteBuilder.setDataIntegers(0, getServiceId());
-        remoteBuilder.setDataIntegers(1, getCount());
+        remoteBuilder.setDataIntegers(1, getChildServiceId());
+        remoteBuilder.setDataIntegers(2, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(3, getChildServiceInstanceId());
+        remoteBuilder.setDataIntegers(4, getCount());
 
         return remoteBuilder;
     }
@@ -106,21 +112,27 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
 
 
         setServiceId(remoteData.getDataIntegers(0));
-        setCount(remoteData.getDataIntegers(1));
+        setChildServiceId(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(2));
+        setChildServiceInstanceId(remoteData.getDataIntegers(3));
+        setCount(remoteData.getDataIntegers(4));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("serviceInstance_resp_time", Scope.ServiceInstance, entityId);
+        return new AlarmMeta("endpoint_relation_resp_time", Scope.EndpointRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointRelationRespTimeIndicator indicator = new EndpointRelationRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setSummation(this.getSummation());
         indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
@@ -130,10 +142,13 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
 
     @Override
     public Indicator toDay() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointRelationRespTimeIndicator indicator = new EndpointRelationRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setSummation(this.getSummation());
         indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
@@ -143,10 +158,13 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
 
     @Override
     public Indicator toMonth() {
-        ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        EndpointRelationRespTimeIndicator indicator = new EndpointRelationRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
+        indicator.setChildServiceId(this.getChildServiceId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setChildServiceInstanceId(this.getChildServiceInstanceId());
         indicator.setSummation(this.getSummation());
         indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
@@ -154,12 +172,15 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceInstanceRespTimeIndicator> {
+    public static class Builder implements StorageBuilder<EndpointRelationRespTimeIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceInstanceRespTimeIndicator storageData) {
+        @Override public Map<String, Object> data2Map(EndpointRelationRespTimeIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
             map.put("service_id", storageData.getServiceId());
+            map.put("child_service_id", storageData.getChildServiceId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("child_service_instance_id", storageData.getChildServiceInstanceId());
             map.put("summation", storageData.getSummation());
             map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
@@ -167,10 +188,13 @@ public class ServiceInstanceRespTimeIndicator extends LongAvgIndicator implement
             return map;
         }
 
-        @Override public ServiceInstanceRespTimeIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceInstanceRespTimeIndicator indicator = new ServiceInstanceRespTimeIndicator();
+        @Override public EndpointRelationRespTimeIndicator map2Data(Map<String, Object> dbMap) {
+            EndpointRelationRespTimeIndicator indicator = new EndpointRelationRespTimeIndicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
+            indicator.setChildServiceId(((Number)dbMap.get("child_service_id")).intValue());
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setChildServiceInstanceId(((Number)dbMap.get("child_service_instance_id")).intValue());
             indicator.setSummation(((Number)dbMap.get("summation")).longValue());
             indicator.setCount(((Number)dbMap.get("count")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCpmIndicator.java
@@ -86,7 +86,8 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
         remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(1, getTotal());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
 
@@ -97,7 +98,8 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
         setEntityId(remoteData.getDataStrings(0));
 
         setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
 
@@ -114,6 +116,7 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -124,6 +127,7 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -134,6 +138,7 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -144,6 +149,7 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
+            map.put("total", storageData.getTotal());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
@@ -152,6 +158,7 @@ public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported 
             ServiceCpmIndicator indicator = new ServiceCpmIndicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceCpmIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_cpm", builder = ServiceCpmIndicator.Builder.class)
+public class ServiceCpmIndicator extends CPMIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceCpmIndicator indicator = (ServiceCpmIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +83,75 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getValue());
+        remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(0));
+        setTimeBucket(remoteData.getDataLongs(1));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_cpm", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceCpmIndicator indicator = new ServiceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceCpmIndicator indicator = new ServiceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceCpmIndicator indicator = new ServiceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceCpmIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceCpmIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public ServiceCpmIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceCpmIndicator indicator = new ServiceCpmIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceDispatcher.java
@@ -30,12 +30,18 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class ServiceDispatcher implements SourceDispatcher<Service> {
 
     @Override public void dispatch(Service source) {
-        doServiceAvg(source);
-        doServiceCallsSum(source);
+        doServiceRespTime(source);
+        doServiceSla(source);
+        doServiceCpm(source);
+        doServiceP99(source);
+        doServiceP95(source);
+        doServiceP90(source);
+        doServiceP75(source);
+        doServiceP50(source);
     }
 
-    private void doServiceAvg(Service source) {
-        ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+    private void doServiceRespTime(Service source) {
+        ServiceRespTimeIndicator indicator = new ServiceRespTimeIndicator();
 
 
         indicator.setTimeBucket(source.getTimeBucket());
@@ -43,13 +49,67 @@ public class ServiceDispatcher implements SourceDispatcher<Service> {
         indicator.combine(source.getLatency(), 1);
         IndicatorProcess.INSTANCE.in(indicator);
     }
-    private void doServiceCallsSum(Service source) {
-        ServiceCallsSumIndicator indicator = new ServiceCallsSumIndicator();
+    private void doServiceSla(Service source) {
+        ServiceSlaIndicator indicator = new ServiceSlaIndicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(new org.apache.skywalking.oap.server.core.analysis.indicator.expression.EqualMatch(), source.isStatus(), true);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceCpm(Service source) {
+        ServiceCpmIndicator indicator = new ServiceCpmIndicator();
 
 
         indicator.setTimeBucket(source.getTimeBucket());
         indicator.setEntityId(source.getEntityId());
         indicator.combine(1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceP99(Service source) {
+        ServiceP99Indicator indicator = new ServiceP99Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceP95(Service source) {
+        ServiceP95Indicator indicator = new ServiceP95Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceP90(Service source) {
+        ServiceP90Indicator indicator = new ServiceP90Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceP75(Service source) {
+        ServiceP75Indicator indicator = new ServiceP75Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 10);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceP50(Service source) {
+        ServiceP50Indicator indicator = new ServiceP50Indicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 10);
         IndicatorProcess.INSTANCE.in(indicator);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP50Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_p50", builder = ServiceP50Indicator.Builder.class)
+public class ServiceP50Indicator extends P50Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceP50Indicator indicator = (ServiceP50Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,6 +83,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
@@ -87,6 +96,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
@@ -102,13 +112,14 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_p50", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP50Indicator indicator = new ServiceP50Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +129,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP50Indicator indicator = new ServiceP50Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +141,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP50Indicator indicator = new ServiceP50Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceP50Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceP50Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +163,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public ServiceP50Indicator map2Data(Map<String, Object> dbMap) {
+            ServiceP50Indicator indicator = new ServiceP50Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP50Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP50Indicator.java
@@ -104,7 +104,7 @@ public class ServiceP50Indicator extends P50Indicator implements AlarmSupported 
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP75Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_p75", builder = ServiceP75Indicator.Builder.class)
+public class ServiceP75Indicator extends P75Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceP75Indicator indicator = (ServiceP75Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,6 +83,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
@@ -87,6 +96,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
@@ -102,13 +112,14 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_p75", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP75Indicator indicator = new ServiceP75Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +129,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP75Indicator indicator = new ServiceP75Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +141,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP75Indicator indicator = new ServiceP75Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceP75Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceP75Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +163,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public ServiceP75Indicator map2Data(Map<String, Object> dbMap) {
+            ServiceP75Indicator indicator = new ServiceP75Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP75Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP75Indicator.java
@@ -104,7 +104,7 @@ public class ServiceP75Indicator extends P75Indicator implements AlarmSupported 
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP90Indicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_p90", builder = ServiceP90Indicator.Builder.class)
+public class ServiceP90Indicator extends P90Indicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceP90Indicator indicator = (ServiceP90Indicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,6 +83,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getTimeBucket());
 
@@ -87,6 +96,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
         setTimeBucket(remoteData.getDataLongs(0));
 
@@ -102,13 +112,14 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_p90", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP90Indicator indicator = new ServiceP90Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -118,8 +129,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP90Indicator indicator = new ServiceP90Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -129,8 +141,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceP90Indicator indicator = new ServiceP90Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
         indicator.setPrecision(this.getPrecision());
         indicator.setDetailGroup(this.getDetailGroup());
@@ -138,10 +151,11 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceP90Indicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceP90Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
             map.put("precision", storageData.getPrecision());
             map.put("detail_group", storageData.getDetailGroup());
@@ -149,8 +163,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
+        @Override public ServiceP90Indicator map2Data(Map<String, Object> dbMap) {
+            ServiceP90Indicator indicator = new ServiceP90Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setValue(((Number)dbMap.get("value")).intValue());
             indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
             indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP90Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP90Indicator.java
@@ -104,7 +104,7 @@ public class ServiceP90Indicator extends P90Indicator implements AlarmSupported 
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP95Indicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
 import lombok.*;
@@ -38,10 +38,10 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "servicerelation_avg", builder = ServiceRelationAvgIndicator.Builder.class)
-public class ServiceRelationAvgIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "service_p95", builder = ServiceP95Indicator.Builder.class)
+public class ServiceP95Indicator extends P95Indicator implements AlarmSupported {
 
-    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -71,7 +71,7 @@ public class ServiceRelationAvgIndicator extends LongAvgIndicator implements Ala
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceRelationAvgIndicator indicator = (ServiceRelationAvgIndicator)obj;
+        ServiceP95Indicator indicator = (ServiceP95Indicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -85,12 +85,12 @@ public class ServiceRelationAvgIndicator extends LongAvgIndicator implements Ala
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getCount());
+        remoteBuilder.setDataIntegers(0, getValue());
+        remoteBuilder.setDataIntegers(1, getPrecision());
+        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
@@ -98,74 +98,77 @@ public class ServiceRelationAvgIndicator extends LongAvgIndicator implements Ala
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setCount(remoteData.getDataIntegers(0));
+        setValue(remoteData.getDataIntegers(0));
+        setPrecision(remoteData.getDataIntegers(1));
 
+        setDetailGroup(new ArrayList<>(30));
+        remoteData.getDataIntLongPairListList().forEach(element -> {
+            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
+        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("ServiceRelation_Avg", Scope.ServiceRelation, entityId);
+        return new AlarmMeta("service_p95", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        ServiceP95Indicator indicator = new ServiceP95Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        ServiceP95Indicator indicator = new ServiceP95Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+        ServiceP95Indicator indicator = new ServiceP95Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceRelationAvgIndicator> {
+    public static class Builder implements StorageBuilder<ServiceP95Indicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceRelationAvgIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceP95Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("source_service_id", storageData.getEntityId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
+            map.put("entity_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
+            map.put("precision", storageData.getPrecision());
+            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceRelationAvgIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
-            indicator.setEntityId((String)dbMap.get("source_service_id"));
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+        @Override public ServiceP95Indicator map2Data(Map<String, Object> dbMap) {
+            ServiceP95Indicator indicator = new ServiceP95Indicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setValue(((Number)dbMap.get("value")).intValue());
+            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP95Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP95Indicator.java
@@ -104,7 +104,7 @@ public class ServiceP95Indicator extends P95Indicator implements AlarmSupported 
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP99Indicator.java
@@ -104,7 +104,7 @@ public class ServiceP99Indicator extends P99Indicator implements AlarmSupported 
         setValue(remoteData.getDataIntegers(0));
         setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
+        setDetailGroup(new IntKeyLongValueArray(30));
         remoteData.getDataIntLongPairListList().forEach(element -> {
             getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
         });

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP99Indicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceP99Indicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmmemorypool;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
 import lombok.*;
@@ -38,11 +38,10 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "instance_jvm_memory_pool_max", builder = InstanceJvmMemoryPoolMaxIndicator.Builder.class)
-public class InstanceJvmMemoryPoolMaxIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "service_p99", builder = ServiceP99Indicator.Builder.class)
+public class ServiceP99Indicator extends P99Indicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
-    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -72,7 +71,7 @@ public class InstanceJvmMemoryPoolMaxIndicator extends LongAvgIndicator implemen
         if (getClass() != obj.getClass())
             return false;
 
-        InstanceJvmMemoryPoolMaxIndicator indicator = (InstanceJvmMemoryPoolMaxIndicator)obj;
+        ServiceP99Indicator indicator = (ServiceP99Indicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -86,13 +85,12 @@ public class InstanceJvmMemoryPoolMaxIndicator extends LongAvgIndicator implemen
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getServiceInstanceId());
-        remoteBuilder.setDataIntegers(1, getCount());
+        remoteBuilder.setDataIntegers(0, getValue());
+        remoteBuilder.setDataIntegers(1, getPrecision());
+        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
@@ -100,80 +98,77 @@ public class InstanceJvmMemoryPoolMaxIndicator extends LongAvgIndicator implemen
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setTimeBucket(remoteData.getDataLongs(0));
 
 
-        setServiceInstanceId(remoteData.getDataIntegers(0));
-        setCount(remoteData.getDataIntegers(1));
+        setValue(remoteData.getDataIntegers(0));
+        setPrecision(remoteData.getDataIntegers(1));
 
+        setDetailGroup(new ArrayList<>(30));
+        remoteData.getDataIntLongPairListList().forEach(element -> {
+            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
+        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("instance_jvm_memory_pool_max", Scope.ServiceInstanceJVMMemoryPool, entityId);
+        return new AlarmMeta("service_p99", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        ServiceP99Indicator indicator = new ServiceP99Indicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        ServiceP99Indicator indicator = new ServiceP99Indicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        ServiceP99Indicator indicator = new ServiceP99Indicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
+        indicator.setPrecision(this.getPrecision());
+        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<InstanceJvmMemoryPoolMaxIndicator> {
+    public static class Builder implements StorageBuilder<ServiceP99Indicator> {
 
-        @Override public Map<String, Object> data2Map(InstanceJvmMemoryPoolMaxIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceP99Indicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
-            map.put("service_instance_id", storageData.getServiceInstanceId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
+            map.put("precision", storageData.getPrecision());
+            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public InstanceJvmMemoryPoolMaxIndicator map2Data(Map<String, Object> dbMap) {
-            InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
+        @Override public ServiceP99Indicator map2Data(Map<String, Object> dbMap) {
+            ServiceP99Indicator indicator = new ServiceP99Indicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
-            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setValue(((Number)dbMap.get("value")).intValue());
+            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
+            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceSlaIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/service/ServiceSlaIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.service;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_sla", builder = ServiceSlaIndicator.Builder.class)
+public class ServiceSlaIndicator extends PercentIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceSlaIndicator indicator = (ServiceSlaIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +83,89 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTotal());
+        remoteBuilder.setDataLongs(1, getMatch());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getPercentage());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setTotal(remoteData.getDataLongs(0));
+        setMatch(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setPercentage(remoteData.getDataIntegers(0));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_sla", Scope.Service, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceSlaIndicator indicator = new ServiceSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceSlaIndicator indicator = new ServiceSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceSlaIndicator indicator = new ServiceSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceSlaIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceSlaIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
+            map.put("entity_id", storageData.getEntityId());
+            map.put("total", storageData.getTotal());
+            map.put("percentage", storageData.getPercentage());
+            map.put("match", storageData.getMatch());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public ServiceSlaIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceSlaIndicator indicator = new ServiceSlaIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
+            indicator.setPercentage(((Number)dbMap.get("percentage")).intValue());
+            indicator.setMatch(((Number)dbMap.get("match")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceCpmIndicator.java
@@ -87,7 +87,8 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
         remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(1, getTotal());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
         remoteBuilder.setDataIntegers(0, getServiceId());
@@ -99,7 +100,8 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
         setEntityId(remoteData.getDataStrings(0));
 
         setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
         setServiceId(remoteData.getDataIntegers(0));
@@ -118,6 +120,7 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -129,6 +132,7 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -140,6 +144,7 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -151,6 +156,7 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
             map.put("entity_id", storageData.getEntityId());
             map.put("service_id", storageData.getServiceId());
             map.put("value", storageData.getValue());
+            map.put("total", storageData.getTotal());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
@@ -160,6 +166,7 @@ public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSu
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceCpmIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstance;
 
 import java.util.*;
 import lombok.*;
@@ -38,10 +38,11 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "service_relation_client_calls_sum", builder = ServiceRelationClientCallsSumIndicator.Builder.class)
-public class ServiceRelationClientCallsSumIndicator extends SumIndicator implements AlarmSupported {
+@StorageEntity(name = "service_instance_cpm", builder = ServiceInstanceCpmIndicator.Builder.class)
+public class ServiceInstanceCpmIndicator extends CPMIndicator implements AlarmSupported {
 
-    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -71,7 +72,7 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceRelationClientCallsSumIndicator indicator = (ServiceRelationClientCallsSumIndicator)obj;
+        ServiceInstanceCpmIndicator indicator = (ServiceInstanceCpmIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -89,6 +90,7 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
         remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
+        remoteBuilder.setDataIntegers(0, getServiceId());
 
         return remoteBuilder;
     }
@@ -100,19 +102,21 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
         setTimeBucket(remoteData.getDataLongs(1));
 
 
+        setServiceId(remoteData.getDataIntegers(0));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("Service_Relation_Client_Calls_Sum", Scope.ServiceRelation, entityId);
+        return new AlarmMeta("service_instance_cpm", Scope.ServiceInstance, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        ServiceInstanceCpmIndicator indicator = new ServiceInstanceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -120,9 +124,10 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
 
     @Override
     public Indicator toDay() {
-        ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        ServiceInstanceCpmIndicator indicator = new ServiceInstanceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -130,27 +135,30 @@ public class ServiceRelationClientCallsSumIndicator extends SumIndicator impleme
 
     @Override
     public Indicator toMonth() {
-        ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+        ServiceInstanceCpmIndicator indicator = new ServiceInstanceCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
+        indicator.setServiceId(this.getServiceId());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceRelationClientCallsSumIndicator> {
+    public static class Builder implements StorageBuilder<ServiceInstanceCpmIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceRelationClientCallsSumIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceInstanceCpmIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("source_service_id", storageData.getEntityId());
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_id", storageData.getServiceId());
             map.put("value", storageData.getValue());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceRelationClientCallsSumIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
-            indicator.setEntityId((String)dbMap.get("source_service_id"));
+        @Override public ServiceInstanceCpmIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceInstanceCpmIndicator indicator = new ServiceInstanceCpmIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstance/ServiceInstanceDispatcher.java
@@ -31,6 +31,7 @@ public class ServiceInstanceDispatcher implements SourceDispatcher<ServiceInstan
     
     @Override public void dispatch(ServiceInstance source) {
         doServiceInstanceRespTime(source);
+        doServiceInstanceCpm(source);
     }
 
     private void doServiceInstanceRespTime(ServiceInstance source) {
@@ -41,6 +42,16 @@ public class ServiceInstanceDispatcher implements SourceDispatcher<ServiceInstan
         indicator.setEntityId(source.getEntityId());
         indicator.setServiceId(source.getServiceId());
         indicator.combine(source.getLatency(), 1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceInstanceCpm(ServiceInstance source) {
+        ServiceInstanceCpmIndicator indicator = new ServiceInstanceCpmIndicator();
+
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceId(source.getServiceId());
+        indicator.combine(1);
         IndicatorProcess.INSTANCE.in(indicator);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmOldGcCountIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmOldGcCountIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmmemory;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmgc;
 
 import java.util.*;
 import lombok.*;
@@ -38,8 +38,8 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "instance_jvm_memory_max", builder = InstanceJvmMemoryMaxIndicator.Builder.class)
-public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "instance_jvm_old_gc_count", builder = InstanceJvmOldGcCountIndicator.Builder.class)
+public class InstanceJvmOldGcCountIndicator extends SumIndicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
     @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
@@ -72,7 +72,7 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
         if (getClass() != obj.getClass())
             return false;
 
-        InstanceJvmMemoryMaxIndicator indicator = (InstanceJvmMemoryMaxIndicator)obj;
+        InstanceJvmOldGcCountIndicator indicator = (InstanceJvmOldGcCountIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -86,13 +86,11 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getValue());
+        remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
         remoteBuilder.setDataIntegers(0, getServiceInstanceId());
-        remoteBuilder.setDataIntegers(1, getCount());
 
         return remoteBuilder;
     }
@@ -100,29 +98,25 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setValue(remoteData.getDataLongs(0));
+        setTimeBucket(remoteData.getDataLongs(1));
 
 
         setServiceInstanceId(remoteData.getDataIntegers(0));
-        setCount(remoteData.getDataIntegers(1));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("instance_jvm_memory_max", Scope.ServiceInstanceJVMMemory, entityId);
+        return new AlarmMeta("instance_jvm_old_gc_count", Scope.ServiceInstanceJVMGC, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        InstanceJvmOldGcCountIndicator indicator = new InstanceJvmOldGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -130,12 +124,10 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
 
     @Override
     public Indicator toDay() {
-        InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        InstanceJvmOldGcCountIndicator indicator = new InstanceJvmOldGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -143,36 +135,30 @@ public class InstanceJvmMemoryMaxIndicator extends LongAvgIndicator implements A
 
     @Override
     public Indicator toMonth() {
-        InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        InstanceJvmOldGcCountIndicator indicator = new InstanceJvmOldGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<InstanceJvmMemoryMaxIndicator> {
+    public static class Builder implements StorageBuilder<InstanceJvmOldGcCountIndicator> {
 
-        @Override public Map<String, Object> data2Map(InstanceJvmMemoryMaxIndicator storageData) {
+        @Override public Map<String, Object> data2Map(InstanceJvmOldGcCountIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("entity_id", storageData.getEntityId());
             map.put("service_instance_id", storageData.getServiceInstanceId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public InstanceJvmMemoryMaxIndicator map2Data(Map<String, Object> dbMap) {
-            InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+        @Override public InstanceJvmOldGcCountIndicator map2Data(Map<String, Object> dbMap) {
+            InstanceJvmOldGcCountIndicator indicator = new InstanceJvmOldGcCountIndicator();
             indicator.setEntityId((String)dbMap.get("entity_id"));
             indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmOldGcTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmOldGcTimeIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmgc;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,21 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "instance_jvm_old_gc_time", builder = InstanceJvmOldGcTimeIndicator.Builder.class)
+public class InstanceJvmOldGcTimeIndicator extends LongAvgIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +60,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +72,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        InstanceJvmOldGcTimeIndicator indicator = (InstanceJvmOldGcTimeIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +84,96 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getSummation());
+        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(1, getCount());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setSummation(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(0));
+        setCount(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("instance_jvm_old_gc_time", Scope.ServiceInstanceJVMGC, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmOldGcTimeIndicator indicator = new InstanceJvmOldGcTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmOldGcTimeIndicator indicator = new InstanceJvmOldGcTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmOldGcTimeIndicator indicator = new InstanceJvmOldGcTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<InstanceJvmOldGcTimeIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(InstanceJvmOldGcTimeIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("summation", storageData.getSummation());
+            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public InstanceJvmOldGcTimeIndicator map2Data(Map<String, Object> dbMap) {
+            InstanceJvmOldGcTimeIndicator indicator = new InstanceJvmOldGcTimeIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
+            indicator.setCount(((Number)dbMap.get("count")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmYoungGcCountIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/InstanceJvmYoungGcCountIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmgc;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,21 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "instance_jvm_young_gc_count", builder = InstanceJvmYoungGcCountIndicator.Builder.class)
+public class InstanceJvmYoungGcCountIndicator extends SumIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +60,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +72,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        InstanceJvmYoungGcCountIndicator indicator = (InstanceJvmYoungGcCountIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +84,82 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getValue());
+        remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getServiceInstanceId());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(0));
+        setTimeBucket(remoteData.getDataLongs(1));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(0));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("instance_jvm_young_gc_count", Scope.ServiceInstanceJVMGC, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmYoungGcCountIndicator indicator = new InstanceJvmYoungGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmYoungGcCountIndicator indicator = new InstanceJvmYoungGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmYoungGcCountIndicator indicator = new InstanceJvmYoungGcCountIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<InstanceJvmYoungGcCountIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(InstanceJvmYoungGcCountIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public InstanceJvmYoungGcCountIndicator map2Data(Map<String, Object> dbMap) {
+            InstanceJvmYoungGcCountIndicator indicator = new InstanceJvmYoungGcCountIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/ServiceInstanceJVMGCDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmgc/ServiceInstanceJVMGCDispatcher.java
@@ -32,6 +32,9 @@ public class ServiceInstanceJVMGCDispatcher implements SourceDispatcher<ServiceI
 
     @Override public void dispatch(ServiceInstanceJVMGC source) {
         doInstanceJvmYoungGcTime(source);
+        doInstanceJvmOldGcTime(source);
+        doInstanceJvmYoungGcCount(source);
+        doInstanceJvmOldGcCount(source);
     }
 
     private void doInstanceJvmYoungGcTime(ServiceInstanceJVMGC source) {
@@ -45,6 +48,45 @@ public class ServiceInstanceJVMGCDispatcher implements SourceDispatcher<ServiceI
         indicator.setEntityId(source.getEntityId());
         indicator.setServiceInstanceId(source.getServiceInstanceId());
         indicator.combine(source.getTime(), 1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doInstanceJvmOldGcTime(ServiceInstanceJVMGC source) {
+        InstanceJvmOldGcTimeIndicator indicator = new InstanceJvmOldGcTimeIndicator();
+
+        if (!new EqualMatch().setLeft(source.getPhrase()).setRight(GCPhrase.OLD).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getTime(), 1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doInstanceJvmYoungGcCount(ServiceInstanceJVMGC source) {
+        InstanceJvmYoungGcCountIndicator indicator = new InstanceJvmYoungGcCountIndicator();
+
+        if (!new EqualMatch().setLeft(source.getPhrase()).setRight(GCPhrase.NEW).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getCount());
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doInstanceJvmOldGcCount(ServiceInstanceJVMGC source) {
+        InstanceJvmOldGcCountIndicator indicator = new InstanceJvmOldGcCountIndicator();
+
+        if (!new EqualMatch().setLeft(source.getPhrase()).setRight(GCPhrase.OLD).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getCount());
         IndicatorProcess.INSTANCE.in(indicator);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryHeapIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryHeapIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmmemory;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,21 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "instance_jvm_memory_heap", builder = InstanceJvmMemoryHeapIndicator.Builder.class)
+public class InstanceJvmMemoryHeapIndicator extends LongAvgIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +60,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +72,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        InstanceJvmMemoryHeapIndicator indicator = (InstanceJvmMemoryHeapIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +84,96 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getSummation());
+        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(1, getCount());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setSummation(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(0));
+        setCount(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("instance_jvm_memory_heap", Scope.ServiceInstanceJVMMemory, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<InstanceJvmMemoryHeapIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(InstanceJvmMemoryHeapIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("summation", storageData.getSummation());
+            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public InstanceJvmMemoryHeapIndicator map2Data(Map<String, Object> dbMap) {
+            InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
+            indicator.setCount(((Number)dbMap.get("count")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryNoheapIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/InstanceJvmMemoryNoheapIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmmemory;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,21 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "instance_jvm_memory_noheap", builder = InstanceJvmMemoryNoheapIndicator.Builder.class)
+public class InstanceJvmMemoryNoheapIndicator extends LongAvgIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +60,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +72,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        InstanceJvmMemoryNoheapIndicator indicator = (InstanceJvmMemoryNoheapIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +84,96 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getSummation());
+        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getServiceInstanceId());
+        remoteBuilder.setDataIntegers(1, getCount());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setSummation(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setServiceInstanceId(remoteData.getDataIntegers(0));
+        setCount(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("instance_jvm_memory_noheap", Scope.ServiceInstanceJVMMemory, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setServiceInstanceId(this.getServiceInstanceId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<InstanceJvmMemoryNoheapIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(InstanceJvmMemoryNoheapIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("entity_id", storageData.getEntityId());
+            map.put("service_instance_id", storageData.getServiceInstanceId());
+            map.put("summation", storageData.getSummation());
+            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public InstanceJvmMemoryNoheapIndicator map2Data(Map<String, Object> dbMap) {
+            InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
+            indicator.setEntityId((String)dbMap.get("entity_id"));
+            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
+            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
+            indicator.setCount(((Number)dbMap.get("count")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/ServiceInstanceJVMMemoryDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/ServiceInstanceJVMMemoryDispatcher.java
@@ -38,7 +38,7 @@ public class ServiceInstanceJVMMemoryDispatcher implements SourceDispatcher<Serv
     private void doInstanceJvmMemoryHeap(ServiceInstanceJVMMemory source) {
         InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
 
-        if (!new EqualMatch().setLeft(source.isIsHeap()).setRight(true).match()) {
+        if (!new EqualMatch().setLeft(source.isHeapStatus()).setRight(true).match()) {
             return;
         }
 
@@ -51,7 +51,7 @@ public class ServiceInstanceJVMMemoryDispatcher implements SourceDispatcher<Serv
     private void doInstanceJvmMemoryNoheap(ServiceInstanceJVMMemory source) {
         InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
 
-        if (!new EqualMatch().setLeft(source.isIsHeap()).setRight(false).match()) {
+        if (!new EqualMatch().setLeft(source.isHeapStatus()).setRight(false).match()) {
             return;
         }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/ServiceInstanceJVMMemoryDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemory/ServiceInstanceJVMMemoryDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstance
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
 import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
+import org.apache.skywalking.oap.server.core.analysis.indicator.expression.*;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**
@@ -30,12 +31,29 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class ServiceInstanceJVMMemoryDispatcher implements SourceDispatcher<ServiceInstanceJVMMemory> {
 
     @Override public void dispatch(ServiceInstanceJVMMemory source) {
-        doInstanceJvmMemoryMax(source);
+        doInstanceJvmMemoryHeap(source);
+        doInstanceJvmMemoryNoheap(source);
     }
 
-    private void doInstanceJvmMemoryMax(ServiceInstanceJVMMemory source) {
-        InstanceJvmMemoryMaxIndicator indicator = new InstanceJvmMemoryMaxIndicator();
+    private void doInstanceJvmMemoryHeap(ServiceInstanceJVMMemory source) {
+        InstanceJvmMemoryHeapIndicator indicator = new InstanceJvmMemoryHeapIndicator();
 
+        if (!new EqualMatch().setLeft(source.isIsHeap()).setRight(true).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.setServiceInstanceId(source.getServiceInstanceId());
+        indicator.combine(source.getMax(), 1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doInstanceJvmMemoryNoheap(ServiceInstanceJVMMemory source) {
+        InstanceJvmMemoryNoheapIndicator indicator = new InstanceJvmMemoryNoheapIndicator();
+
+        if (!new EqualMatch().setLeft(source.isIsHeap()).setRight(false).match()) {
+            return;
+        }
 
         indicator.setTimeBucket(source.getTimeBucket());
         indicator.setEntityId(source.getEntityId());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemorypool/ServiceInstanceJVMMemoryPoolDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancejvmmemorypool/ServiceInstanceJVMMemoryPoolDispatcher.java
@@ -19,7 +19,6 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancejvmmemorypool;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**
@@ -30,17 +29,6 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class ServiceInstanceJVMMemoryPoolDispatcher implements SourceDispatcher<ServiceInstanceJVMMemoryPool> {
 
     @Override public void dispatch(ServiceInstanceJVMMemoryPool source) {
-        doInstanceJvmMemoryPoolMax(source);
     }
 
-    private void doInstanceJvmMemoryPoolMax(ServiceInstanceJVMMemoryPool source) {
-        InstanceJvmMemoryPoolMaxIndicator indicator = new InstanceJvmMemoryPoolMaxIndicator();
-
-
-        indicator.setTimeBucket(source.getTimeBucket());
-        indicator.setEntityId(source.getEntityId());
-        indicator.setServiceInstanceId(source.getServiceInstanceId());
-        indicator.combine(source.getMax(), 1);
-        IndicatorProcess.INSTANCE.in(indicator);
-    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancerelation/ServiceInstanceRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/serviceinstancerelation/ServiceInstanceRelationDispatcher.java
@@ -19,7 +19,6 @@
 package org.apache.skywalking.oap.server.core.analysis.generated.serviceinstancerelation;
 
 import org.apache.skywalking.oap.server.core.analysis.SourceDispatcher;
-import org.apache.skywalking.oap.server.core.analysis.worker.IndicatorProcess;
 import org.apache.skywalking.oap.server.core.source.*;
 
 /**
@@ -30,18 +29,6 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class ServiceInstanceRelationDispatcher implements SourceDispatcher<ServiceInstanceRelation> {
 
     @Override public void dispatch(ServiceInstanceRelation source) {
-        doServiceInstanceRelationAvg(source);
     }
 
-    private void doServiceInstanceRelationAvg(ServiceInstanceRelation source) {
-        ServiceInstanceRelationAvgIndicator indicator = new ServiceInstanceRelationAvgIndicator();
-
-
-        indicator.setTimeBucket(source.getTimeBucket());
-        indicator.setEntityId(source.getEntityId());
-        indicator.setSourceServiceId(source.getSourceServiceId());
-        indicator.setDestServiceId(source.getDestServiceId());
-        indicator.combine(source.getLatency(), 1);
-        IndicatorProcess.INSTANCE.in(indicator);
-    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCallSlaIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCallSlaIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.service;
+package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import java.util.*;
 import lombok.*;
@@ -38,10 +38,10 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "service_avg", builder = ServiceAvgIndicator.Builder.class)
-public class ServiceAvgIndicator extends LongAvgIndicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_client_call_sla", builder = ServiceRelationClientCallSlaIndicator.Builder.class)
+public class ServiceRelationClientCallSlaIndicator extends PercentIndicator implements AlarmSupported {
 
-    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
+    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -71,7 +71,7 @@ public class ServiceAvgIndicator extends LongAvgIndicator implements AlarmSuppor
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceAvgIndicator indicator = (ServiceAvgIndicator)obj;
+        ServiceRelationClientCallSlaIndicator indicator = (ServiceRelationClientCallSlaIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -85,12 +85,12 @@ public class ServiceAvgIndicator extends LongAvgIndicator implements AlarmSuppor
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getSummation());
-        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(0, getTotal());
+        remoteBuilder.setDataLongs(1, getMatch());
         remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getCount());
+        remoteBuilder.setDataIntegers(0, getPercentage());
 
         return remoteBuilder;
     }
@@ -98,74 +98,74 @@ public class ServiceAvgIndicator extends LongAvgIndicator implements AlarmSuppor
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setSummation(remoteData.getDataLongs(0));
-        setValue(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(0));
+        setMatch(remoteData.getDataLongs(1));
         setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setCount(remoteData.getDataIntegers(0));
+        setPercentage(remoteData.getDataIntegers(0));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("Service_Avg", Scope.Service, entityId);
+        return new AlarmMeta("service_relation_client_call_sla", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        ServiceRelationClientCallSlaIndicator indicator = new ServiceRelationClientCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        ServiceRelationClientCallSlaIndicator indicator = new ServiceRelationClientCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        ServiceAvgIndicator indicator = new ServiceAvgIndicator();
+        ServiceRelationClientCallSlaIndicator indicator = new ServiceRelationClientCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
-        indicator.setSummation(this.getSummation());
-        indicator.setCount(this.getCount());
-        indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceAvgIndicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationClientCallSlaIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceAvgIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationClientCallSlaIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("entity_id", storageData.getEntityId());
-            map.put("summation", storageData.getSummation());
-            map.put("count", storageData.getCount());
-            map.put("value", storageData.getValue());
+            map.put("source_service_id", storageData.getEntityId());
+            map.put("total", storageData.getTotal());
+            map.put("percentage", storageData.getPercentage());
+            map.put("match", storageData.getMatch());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceAvgIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceAvgIndicator indicator = new ServiceAvgIndicator();
-            indicator.setEntityId((String)dbMap.get("entity_id"));
-            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
-            indicator.setCount(((Number)dbMap.get("count")).intValue());
-            indicator.setValue(((Number)dbMap.get("value")).longValue());
+        @Override public ServiceRelationClientCallSlaIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationClientCallSlaIndicator indicator = new ServiceRelationClientCallSlaIndicator();
+            indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
+            indicator.setPercentage(((Number)dbMap.get("percentage")).intValue());
+            indicator.setMatch(((Number)dbMap.get("match")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCpmIndicator.java
@@ -86,7 +86,8 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
         remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(1, getTotal());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
 
@@ -97,7 +98,8 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
         setEntityId(remoteData.getDataStrings(0));
 
         setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
 
@@ -114,6 +116,7 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -124,6 +127,7 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -134,6 +138,7 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -144,6 +149,7 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
             Map<String, Object> map = new HashMap<>();
             map.put("source_service_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
+            map.put("total", storageData.getTotal());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
@@ -152,6 +158,7 @@ public class ServiceRelationClientCpmIndicator extends CPMIndicator implements A
             ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
             indicator.setEntityId((String)dbMap.get("source_service_id"));
             indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientCpmIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_client_cpm", builder = ServiceRelationClientCpmIndicator.Builder.class)
+public class ServiceRelationClientCpmIndicator extends CPMIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceRelationClientCpmIndicator indicator = (ServiceRelationClientCpmIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +83,75 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getValue());
+        remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(0));
+        setTimeBucket(remoteData.getDataLongs(1));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_relation_client_cpm", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationClientCpmIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationClientCpmIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("source_service_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public ServiceRelationClientCpmIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
+            indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientRespTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationClientRespTimeIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_client_resp_time", builder = ServiceRelationClientRespTimeIndicator.Builder.class)
+public class ServiceRelationClientRespTimeIndicator extends LongAvgIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceRelationClientRespTimeIndicator indicator = (ServiceRelationClientRespTimeIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +83,89 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getSummation());
+        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getCount());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setSummation(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setCount(remoteData.getDataIntegers(0));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_relation_client_resp_time", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientRespTimeIndicator indicator = new ServiceRelationClientRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientRespTimeIndicator indicator = new ServiceRelationClientRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationClientRespTimeIndicator indicator = new ServiceRelationClientRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationClientRespTimeIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationClientRespTimeIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
+            map.put("source_service_id", storageData.getEntityId());
+            map.put("summation", storageData.getSummation());
+            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public ServiceRelationClientRespTimeIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationClientRespTimeIndicator indicator = new ServiceRelationClientRespTimeIndicator();
+            indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
+            indicator.setCount(((Number)dbMap.get("count")).intValue());
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationDispatcher.java
@@ -31,13 +31,16 @@ import org.apache.skywalking.oap.server.core.source.*;
 public class ServiceRelationDispatcher implements SourceDispatcher<ServiceRelation> {
 
     @Override public void dispatch(ServiceRelation source) {
-        doServiceRelationClientCallsSum(source);
-        doServiceRelationServerCallsSum(source);
-        doServiceRelationAvg(source);
+        doServiceRelationClientCpm(source);
+        doServiceRelationServerCpm(source);
+        doServiceRelationClientCallSla(source);
+        doServiceRelationServerCallSla(source);
+        doServiceRelationClientRespTime(source);
+        doServiceRelationServerRespTime(source);
     }
 
-    private void doServiceRelationClientCallsSum(ServiceRelation source) {
-        ServiceRelationClientCallsSumIndicator indicator = new ServiceRelationClientCallsSumIndicator();
+    private void doServiceRelationClientCpm(ServiceRelation source) {
+        ServiceRelationClientCpmIndicator indicator = new ServiceRelationClientCpmIndicator();
 
         if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.CLIENT).match()) {
             return;
@@ -48,8 +51,8 @@ public class ServiceRelationDispatcher implements SourceDispatcher<ServiceRelati
         indicator.combine(1);
         IndicatorProcess.INSTANCE.in(indicator);
     }
-    private void doServiceRelationServerCallsSum(ServiceRelation source) {
-        ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+    private void doServiceRelationServerCpm(ServiceRelation source) {
+        ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
 
         if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.SERVER).match()) {
             return;
@@ -60,9 +63,48 @@ public class ServiceRelationDispatcher implements SourceDispatcher<ServiceRelati
         indicator.combine(1);
         IndicatorProcess.INSTANCE.in(indicator);
     }
-    private void doServiceRelationAvg(ServiceRelation source) {
-        ServiceRelationAvgIndicator indicator = new ServiceRelationAvgIndicator();
+    private void doServiceRelationClientCallSla(ServiceRelation source) {
+        ServiceRelationClientCallSlaIndicator indicator = new ServiceRelationClientCallSlaIndicator();
 
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.CLIENT).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(new org.apache.skywalking.oap.server.core.analysis.indicator.expression.EqualMatch(), source.isStatus(), true);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceRelationServerCallSla(ServiceRelation source) {
+        ServiceRelationServerCallSlaIndicator indicator = new ServiceRelationServerCallSlaIndicator();
+
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.SERVER).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(new org.apache.skywalking.oap.server.core.analysis.indicator.expression.EqualMatch(), source.isStatus(), true);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceRelationClientRespTime(ServiceRelation source) {
+        ServiceRelationClientRespTimeIndicator indicator = new ServiceRelationClientRespTimeIndicator();
+
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.CLIENT).match()) {
+            return;
+        }
+
+        indicator.setTimeBucket(source.getTimeBucket());
+        indicator.setEntityId(source.getEntityId());
+        indicator.combine(source.getLatency(), 1);
+        IndicatorProcess.INSTANCE.in(indicator);
+    }
+    private void doServiceRelationServerRespTime(ServiceRelation source) {
+        ServiceRelationServerRespTimeIndicator indicator = new ServiceRelationServerRespTimeIndicator();
+
+        if (!new EqualMatch().setLeft(source.getDetectPoint()).setRight(DetectPoint.SERVER).match()) {
+            return;
+        }
 
         indicator.setTimeBucket(source.getTimeBucket());
         indicator.setEntityId(source.getEntityId());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCallSlaIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCallSlaIndicator.java
@@ -16,9 +16,11 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.all;
+package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import java.util.*;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.alarm.AlarmMeta;
 import org.apache.skywalking.oap.server.core.alarm.AlarmSupported;
 import org.apache.skywalking.oap.server.core.analysis.indicator.*;
@@ -36,17 +38,20 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "all_p95", builder = AllP95Indicator.Builder.class)
-public class AllP95Indicator extends P95Indicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_server_call_sla", builder = ServiceRelationServerCallSlaIndicator.Builder.class)
+public class ServiceRelationServerCallSlaIndicator extends PercentIndicator implements AlarmSupported {
 
+    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
+        splitJointId += Const.ID_SPLIT + entityId;
         return splitJointId;
     }
 
     @Override public int hashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         result = 31 * result + (int)getTimeBucket();
         return result;
     }
@@ -54,6 +59,7 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public int remoteHashCode() {
         int result = 17;
+        result = 31 * result + entityId.hashCode();
         return result;
     }
 
@@ -65,7 +71,9 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
         if (getClass() != obj.getClass())
             return false;
 
-        AllP95Indicator indicator = (AllP95Indicator)obj;
+        ServiceRelationServerCallSlaIndicator indicator = (ServiceRelationServerCallSlaIndicator)obj;
+        if (entityId != indicator.entityId)
+            return false;
 
         if (getTimeBucket() != indicator.getTimeBucket())
             return false;
@@ -75,85 +83,89 @@ public class AllP95Indicator extends P95Indicator implements AlarmSupported {
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
+        remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getTotal());
+        remoteBuilder.setDataLongs(1, getMatch());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getValue());
-        remoteBuilder.setDataIntegers(1, getPrecision());
-        getDetailGroup().forEach(element -> remoteBuilder.addDataIntLongPairList(element.serialize()));
+        remoteBuilder.setDataIntegers(0, getPercentage());
 
         return remoteBuilder;
     }
 
     @Override public void deserialize(RemoteData remoteData) {
+        setEntityId(remoteData.getDataStrings(0));
 
-        setTimeBucket(remoteData.getDataLongs(0));
+        setTotal(remoteData.getDataLongs(0));
+        setMatch(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
-        setValue(remoteData.getDataIntegers(0));
-        setPrecision(remoteData.getDataIntegers(1));
+        setPercentage(remoteData.getDataIntegers(0));
 
-        setDetailGroup(new ArrayList<>(30));
-        remoteData.getDataIntLongPairListList().forEach(element -> {
-            getDetailGroup().add(new IntKeyLongValue(element.getKey(), element.getValue()));
-        });
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("all_p95", Scope.All);
+        return new AlarmMeta("service_relation_server_call_sla", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationServerCallSlaIndicator indicator = new ServiceRelationServerCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationServerCallSlaIndicator indicator = new ServiceRelationServerCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        AllP95Indicator indicator = new AllP95Indicator();
+        ServiceRelationServerCallSlaIndicator indicator = new ServiceRelationServerCallSlaIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
-        indicator.setValue(this.getValue());
-        indicator.setPrecision(this.getPrecision());
-        indicator.setDetailGroup(this.getDetailGroup());
+        indicator.setEntityId(this.getEntityId());
+        indicator.setTotal(this.getTotal());
+        indicator.setPercentage(this.getPercentage());
+        indicator.setMatch(this.getMatch());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<AllP95Indicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationServerCallSlaIndicator> {
 
-        @Override public Map<String, Object> data2Map(AllP95Indicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationServerCallSlaIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("value", storageData.getValue());
-            map.put("precision", storageData.getPrecision());
-            map.put("detail_group", storageData.getDetailGroup());
+            map.put("source_service_id", storageData.getEntityId());
+            map.put("total", storageData.getTotal());
+            map.put("percentage", storageData.getPercentage());
+            map.put("match", storageData.getMatch());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public AllP95Indicator map2Data(Map<String, Object> dbMap) {
-            AllP95Indicator indicator = new AllP95Indicator();
-            indicator.setValue(((Number)dbMap.get("value")).intValue());
-            indicator.setPrecision(((Number)dbMap.get("precision")).intValue());
-            indicator.setDetailGroup((org.apache.skywalking.oap.server.core.analysis.indicator.IntKeyLongValueArray)dbMap.get("detail_group"));
+        @Override public ServiceRelationServerCallSlaIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationServerCallSlaIndicator indicator = new ServiceRelationServerCallSlaIndicator();
+            indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
+            indicator.setPercentage(((Number)dbMap.get("percentage")).intValue());
+            indicator.setMatch(((Number)dbMap.get("match")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCpmIndicator.java
@@ -86,7 +86,8 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
         remoteBuilder.setDataStrings(0, getEntityId());
 
         remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(1, getTotal());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
 
@@ -97,7 +98,8 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
         setEntityId(remoteData.getDataStrings(0));
 
         setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setTotal(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
 
@@ -114,6 +116,7 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -124,6 +127,7 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -134,6 +138,7 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
         indicator.setValue(this.getValue());
+        indicator.setTotal(this.getTotal());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
@@ -144,6 +149,7 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
             Map<String, Object> map = new HashMap<>();
             map.put("source_service_id", storageData.getEntityId());
             map.put("value", storageData.getValue());
+            map.put("total", storageData.getTotal());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
@@ -152,6 +158,7 @@ public class ServiceRelationServerCpmIndicator extends CPMIndicator implements A
             ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
             indicator.setEntityId((String)dbMap.get("source_service_id"));
             indicator.setValue(((Number)dbMap.get("value")).longValue());
+            indicator.setTotal(((Number)dbMap.get("total")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCpmIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerCpmIndicator.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.skywalking.oap.server.core.analysis.generated.endpoint;
+package org.apache.skywalking.oap.server.core.analysis.generated.servicerelation;
 
 import java.util.*;
 import lombok.*;
@@ -38,12 +38,10 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "endpoint_percent", builder = EndpointPercentIndicator.Builder.class)
-public class EndpointPercentIndicator extends PercentIndicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_server_cpm", builder = ServiceRelationServerCpmIndicator.Builder.class)
+public class ServiceRelationServerCpmIndicator extends CPMIndicator implements AlarmSupported {
 
-    @Setter @Getter @Column(columnName = "entity_id") @IDColumn private String entityId;
-    @Setter @Getter @Column(columnName = "service_id")  private int serviceId;
-    @Setter @Getter @Column(columnName = "service_instance_id")  private int serviceInstanceId;
+    @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
     @Override public String id() {
         String splitJointId = String.valueOf(getTimeBucket());
@@ -73,7 +71,7 @@ public class EndpointPercentIndicator extends PercentIndicator implements AlarmS
         if (getClass() != obj.getClass())
             return false;
 
-        EndpointPercentIndicator indicator = (EndpointPercentIndicator)obj;
+        ServiceRelationServerCpmIndicator indicator = (ServiceRelationServerCpmIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -87,14 +85,10 @@ public class EndpointPercentIndicator extends PercentIndicator implements AlarmS
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getTotal());
-        remoteBuilder.setDataLongs(1, getMatch());
-        remoteBuilder.setDataLongs(2, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getValue());
+        remoteBuilder.setDataLongs(1, getTimeBucket());
 
 
-        remoteBuilder.setDataIntegers(0, getServiceId());
-        remoteBuilder.setDataIntegers(1, getServiceInstanceId());
-        remoteBuilder.setDataIntegers(2, getPercentage());
 
         return remoteBuilder;
     }
@@ -102,86 +96,62 @@ public class EndpointPercentIndicator extends PercentIndicator implements AlarmS
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setTotal(remoteData.getDataLongs(0));
-        setMatch(remoteData.getDataLongs(1));
-        setTimeBucket(remoteData.getDataLongs(2));
+        setValue(remoteData.getDataLongs(0));
+        setTimeBucket(remoteData.getDataLongs(1));
 
 
-        setServiceId(remoteData.getDataIntegers(0));
-        setServiceInstanceId(remoteData.getDataIntegers(1));
-        setPercentage(remoteData.getDataIntegers(2));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("endpoint_percent", Scope.Endpoint, entityId);
+        return new AlarmMeta("service_relation_server_cpm", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceId(this.getServiceId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setTotal(this.getTotal());
-        indicator.setPercentage(this.getPercentage());
-        indicator.setMatch(this.getMatch());
+        indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toDay() {
-        EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceId(this.getServiceId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setTotal(this.getTotal());
-        indicator.setPercentage(this.getPercentage());
-        indicator.setMatch(this.getMatch());
+        indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
     @Override
     public Indicator toMonth() {
-        EndpointPercentIndicator indicator = new EndpointPercentIndicator();
+        ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
-        indicator.setServiceId(this.getServiceId());
-        indicator.setServiceInstanceId(this.getServiceInstanceId());
-        indicator.setTotal(this.getTotal());
-        indicator.setPercentage(this.getPercentage());
-        indicator.setMatch(this.getMatch());
+        indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<EndpointPercentIndicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationServerCpmIndicator> {
 
-        @Override public Map<String, Object> data2Map(EndpointPercentIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationServerCpmIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
-            map.put("entity_id", storageData.getEntityId());
-            map.put("service_id", storageData.getServiceId());
-            map.put("service_instance_id", storageData.getServiceInstanceId());
-            map.put("total", storageData.getTotal());
-            map.put("percentage", storageData.getPercentage());
-            map.put("match", storageData.getMatch());
+            map.put("source_service_id", storageData.getEntityId());
+            map.put("value", storageData.getValue());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public EndpointPercentIndicator map2Data(Map<String, Object> dbMap) {
-            EndpointPercentIndicator indicator = new EndpointPercentIndicator();
-            indicator.setEntityId((String)dbMap.get("entity_id"));
-            indicator.setServiceId(((Number)dbMap.get("service_id")).intValue());
-            indicator.setServiceInstanceId(((Number)dbMap.get("service_instance_id")).intValue());
-            indicator.setTotal(((Number)dbMap.get("total")).longValue());
-            indicator.setPercentage(((Number)dbMap.get("percentage")).intValue());
-            indicator.setMatch(((Number)dbMap.get("match")).longValue());
+        @Override public ServiceRelationServerCpmIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationServerCpmIndicator indicator = new ServiceRelationServerCpmIndicator();
+            indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerRespTimeIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/generated/servicerelation/ServiceRelationServerRespTimeIndicator.java
@@ -38,8 +38,8 @@ import org.apache.skywalking.oap.server.core.source.Scope;
  */
 @IndicatorType
 @StreamData
-@StorageEntity(name = "service_relation_server_calls_sum", builder = ServiceRelationServerCallsSumIndicator.Builder.class)
-public class ServiceRelationServerCallsSumIndicator extends SumIndicator implements AlarmSupported {
+@StorageEntity(name = "service_relation_server_resp_time", builder = ServiceRelationServerRespTimeIndicator.Builder.class)
+public class ServiceRelationServerRespTimeIndicator extends LongAvgIndicator implements AlarmSupported {
 
     @Setter @Getter @Column(columnName = "source_service_id") @IDColumn private String entityId;
 
@@ -71,7 +71,7 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
         if (getClass() != obj.getClass())
             return false;
 
-        ServiceRelationServerCallsSumIndicator indicator = (ServiceRelationServerCallsSumIndicator)obj;
+        ServiceRelationServerRespTimeIndicator indicator = (ServiceRelationServerRespTimeIndicator)obj;
         if (entityId != indicator.entityId)
             return false;
 
@@ -85,10 +85,12 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.setDataStrings(0, getEntityId());
 
-        remoteBuilder.setDataLongs(0, getValue());
-        remoteBuilder.setDataLongs(1, getTimeBucket());
+        remoteBuilder.setDataLongs(0, getSummation());
+        remoteBuilder.setDataLongs(1, getValue());
+        remoteBuilder.setDataLongs(2, getTimeBucket());
 
 
+        remoteBuilder.setDataIntegers(0, getCount());
 
         return remoteBuilder;
     }
@@ -96,23 +98,27 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
     @Override public void deserialize(RemoteData remoteData) {
         setEntityId(remoteData.getDataStrings(0));
 
-        setValue(remoteData.getDataLongs(0));
-        setTimeBucket(remoteData.getDataLongs(1));
+        setSummation(remoteData.getDataLongs(0));
+        setValue(remoteData.getDataLongs(1));
+        setTimeBucket(remoteData.getDataLongs(2));
 
 
+        setCount(remoteData.getDataIntegers(0));
 
 
     }
 
     @Override public AlarmMeta getAlarmMeta() {
-        return new AlarmMeta("Service_Relation_Server_Calls_Sum", Scope.ServiceRelation, entityId);
+        return new AlarmMeta("service_relation_server_resp_time", Scope.ServiceRelation, entityId);
     }
 
     @Override
     public Indicator toHour() {
-        ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+        ServiceRelationServerRespTimeIndicator indicator = new ServiceRelationServerRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInHour());
         indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -120,9 +126,11 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
 
     @Override
     public Indicator toDay() {
-        ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+        ServiceRelationServerRespTimeIndicator indicator = new ServiceRelationServerRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInDay());
         indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
@@ -130,27 +138,33 @@ public class ServiceRelationServerCallsSumIndicator extends SumIndicator impleme
 
     @Override
     public Indicator toMonth() {
-        ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+        ServiceRelationServerRespTimeIndicator indicator = new ServiceRelationServerRespTimeIndicator();
         indicator.setTimeBucket(toTimeBucketInMonth());
         indicator.setEntityId(this.getEntityId());
+        indicator.setSummation(this.getSummation());
+        indicator.setCount(this.getCount());
         indicator.setValue(this.getValue());
         indicator.setTimeBucket(this.getTimeBucket());
         return indicator;
     }
 
-    public static class Builder implements StorageBuilder<ServiceRelationServerCallsSumIndicator> {
+    public static class Builder implements StorageBuilder<ServiceRelationServerRespTimeIndicator> {
 
-        @Override public Map<String, Object> data2Map(ServiceRelationServerCallsSumIndicator storageData) {
+        @Override public Map<String, Object> data2Map(ServiceRelationServerRespTimeIndicator storageData) {
             Map<String, Object> map = new HashMap<>();
             map.put("source_service_id", storageData.getEntityId());
+            map.put("summation", storageData.getSummation());
+            map.put("count", storageData.getCount());
             map.put("value", storageData.getValue());
             map.put("time_bucket", storageData.getTimeBucket());
             return map;
         }
 
-        @Override public ServiceRelationServerCallsSumIndicator map2Data(Map<String, Object> dbMap) {
-            ServiceRelationServerCallsSumIndicator indicator = new ServiceRelationServerCallsSumIndicator();
+        @Override public ServiceRelationServerRespTimeIndicator map2Data(Map<String, Object> dbMap) {
+            ServiceRelationServerRespTimeIndicator indicator = new ServiceRelationServerRespTimeIndicator();
             indicator.setEntityId((String)dbMap.get("source_service_id"));
+            indicator.setSummation(((Number)dbMap.get("summation")).longValue());
+            indicator.setCount(((Number)dbMap.get("count")).intValue());
             indicator.setValue(((Number)dbMap.get("value")).longValue());
             indicator.setTimeBucket(((Number)dbMap.get("time_bucket")).longValue());
             return indicator;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CPMIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CPMIndicator.java
@@ -20,35 +20,37 @@ package org.apache.skywalking.oap.server.core.analysis.indicator;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.ConstOne;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.Entrance;
 import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorOperator;
-import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.SourceFrom;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 
 /**
  * @author wusheng
  */
 @IndicatorOperator
-public abstract class SumIndicator extends Indicator implements LongValueHolder {
+public abstract class CPMIndicator extends Indicator implements LongValueHolder {
 
     protected static final String VALUE = "value";
 
     @Getter @Setter @Column(columnName = VALUE) private long value;
 
     @Entrance
-    public final void combine(@SourceFrom long count) {
+    public final void combine(@ConstOne long count) {
         this.value += count;
     }
 
     @Override public final void combine(Indicator indicator) {
-        SumIndicator countIndicator = (SumIndicator)indicator;
+        CPMIndicator countIndicator = (CPMIndicator)indicator;
         combine(countIndicator.value);
     }
 
     @Override public void calculate() {
+
     }
 
     @Override public long getValue() {
         return value;
     }
 }
+

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CPMIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CPMIndicator.java
@@ -32,21 +32,23 @@ import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 public abstract class CPMIndicator extends Indicator implements LongValueHolder {
 
     protected static final String VALUE = "value";
+    protected static final String TOTAL = "total";
 
     @Getter @Setter @Column(columnName = VALUE) private long value;
+    @Getter @Setter @Column(columnName = TOTAL) private long total;
 
     @Entrance
     public final void combine(@ConstOne long count) {
-        this.value += count;
+        this.total += count;
     }
 
     @Override public final void combine(Indicator indicator) {
         CPMIndicator countIndicator = (CPMIndicator)indicator;
-        combine(countIndicator.value);
+        combine(countIndicator.total);
     }
 
     @Override public void calculate() {
-
+        this.value = total / getDurationInMinute();
     }
 
     @Override public long getValue() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CountIndicator.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/indicator/CountIndicator.java
@@ -18,30 +18,27 @@
 
 package org.apache.skywalking.oap.server.core.analysis.indicator;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.Entrance;
-import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.IndicatorOperator;
-import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.SourceFrom;
+import lombok.*;
+import org.apache.skywalking.oap.server.core.analysis.indicator.annotation.*;
 import org.apache.skywalking.oap.server.core.storage.annotation.Column;
 
 /**
- * @author wusheng
+ * @author peng-yongsheng
  */
 @IndicatorOperator
-public abstract class SumIndicator extends Indicator implements LongValueHolder {
+public abstract class CountIndicator extends Indicator implements LongValueHolder {
 
     protected static final String VALUE = "value";
 
     @Getter @Setter @Column(columnName = VALUE) private long value;
 
     @Entrance
-    public final void combine(@SourceFrom long count) {
+    public final void combine(@ConstOne long count) {
         this.value += count;
     }
 
     @Override public final void combine(Indicator indicator) {
-        SumIndicator countIndicator = (SumIndicator)indicator;
+        CountIndicator countIndicator = (CountIndicator)indicator;
         combine(countIndicator.value);
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
@@ -36,7 +36,7 @@ public class ServiceInstanceJVMMemory extends Source {
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
     @Getter @Setter private int serviceInstanceId;
-    @Getter @Setter private boolean isHeap;
+    @Getter @Setter private boolean heapStatus;
     @Getter @Setter private long init;
     @Getter @Setter private long max;
     @Getter @Setter private long used;

--- a/oap-server/server-core/src/main/resources/official_analysis.oal
+++ b/oap-server/server-core/src/main/resources/official_analysis.oal
@@ -1,78 +1,72 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
+// All scope metric
+all_p99 = from(All.latency).p99(10);
+all_p95 = from(All.latency).p95(10);
+all_p90 = from(All.latency).p90(10);
+all_p75 = from(All.latency).p75(10);
+all_p50 = from(All.latency).p50(10);
+all_heatmap = from(All.latency).thermodynamic(100, 20);
 
-// Dashbard
+// Service scope metric
+service_resp_time = from(Service.latency).longAvg();
+service_sla = from(Service.*).percent(status == true);
+service_cpm = from(Service.*).cpm();
+service_p99 = from(Service.latency).p99(10);
+service_p95 = from(Service.latency).p95(10);
+service_p90 = from(Service.latency).p90(10);
+service_p75 = from(Service.latency).p75(10);
+service_p50 = from(Service.latency).p50(10);
 
-AlarmTrend = from(Alarm).langAvg(); // Mock
-Thermodynamic = from(Trace).histogram(0, 100); // Mock
+// Service relation scope metric for topology
+service_relation_client_cpm = from(ServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).cpm();
+service_relation_server_cpm = from(ServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
+service_relation_client_call_sla = from(ServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).percent(status == true);
+service_relation_server_call_sla = from(ServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).percent(status == true);
+service_relation_client_resp_time = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.CLIENT).longAvg();
+service_relation_server_resp_time = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.SERVER).longAvg();
 
-// Service on Topology
+// Service Instance Scope metric
+serviceInstance_resp_time= from(ServiceInstance.latency).longAvg();
+service_instance_cpm = from(ServiceInstance.*).cpm();
 
-Service_Avg = from(Service.latency).longAvg();
-
-Service_Throughput = from(Service.*).sum();
-
-Service_percent = from(Endpoint.*).percent(status == true);
-
-Service_apdex  = from(Endpoint.*).apdex();  //Mock
-
-ServiceRelation_Avg = from(ServiceRelation.latency).langAvg();
-
-ServiceRelation_Throughput = from(ServiceRelation.*).sum();
-
-
-// ServiceInstance
-ResponseTimeTrend_avg = from(ServiceInstance.latency).longAvg();
-
-ResponseTimeTrend_p99 = from(ServiceInstance.latency).p99();
-
-ResponseTimeTrend_p95 = from(ServiceInstance.latency).p95();
-
-ResponseTimeTrend_p75 = from(ServiceInstance.latency).p75();
-
-ResponseTimeTrend_p50 = from(ServiceInstance.latency).p50();
-
-ThroughputTrend = from(ServiceInstance.*).sum();
-
-instance_jvm_cpu = from(ServiceInstanceJVMCPU.usePercent).doubleAvg();
-
-instance_jvm_memory_max = from(ServiceInstanceJVMMemory.max).longAvg();
-
-instance_jvm_memory_pool_max = from(ServiceInstanceJVMMemoryPool.max).longAvg();
-
-instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).longAvg();
-
-// Endpoint
+// Endpoint scope metric
 endpoint_Avg = from(Endpoint.latency).longAvg();
+endpoint_sla = from(Endpoint.*).percent(status == true);
+endpoint_p99 = from(Endpoint.latency).p99(10);
+endpoint_p95 = from(Endpoint.latency).p95(10);
+endpoint_p90 = from(Endpoint.latency).p90(10);
+endpoint_p75 = from(Endpoint.latency).p75(10);
+endpoint_p50 = from(Endpoint.latency).p50(10);
 
-endpoint_p99 = from(Endpoint.latency).p99();
+// Endpoint relation scope metric
+endpoint_relation_cpm = from(EndpointRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
+endpoint_relation_resp_time = from(EndpointRelation.rpcLatency).filter(detectPoint == DetectPoint.SERVER).longAvg();
 
-endpoint_p95 = from(Endpoint.latency).p95();
+// JVM instance metric
+instance_jvm_cpu = from(ServiceInstanceJVMCPU.usePercent).doubleAvg();
+instance_jvm_memory_heap = from(ServiceInstanceJVMMemory.max).filter(isHeap == true).longAvg();
+instance_jvm_memory_noheap = from(ServiceInstanceJVMMemory.max).filter(isHeap == false).longAvg();
+instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).longAvg();
+instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).longAvg();
+instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
+instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();
 
-endpoint_p75 = from(Endpoint.latency).p75();
 
-endpoint_p50 = from(Endpoint.latency).p50();
-
-endpoint_throughput = from(Endpoint.*).sum();
-
-endpoint_percent = from(Endpoint.*).percent(status == true);
-
-EndpointRelation_Avg = from(EndpointRelation.latency).langAvg();
-
-EndpointRelation_Throughput = from(EndpointRelation.*).sum();
+// endpoint_Avg_for_prod_serv = from(Endpoint.latency).filter(name == "/product/service").longAvg();

--- a/oap-server/server-core/src/main/resources/official_analysis.oal
+++ b/oap-server/server-core/src/main/resources/official_analysis.oal
@@ -67,6 +67,3 @@ instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GC
 instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).longAvg();
 instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
 instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();
-
-
-// endpoint_Avg_for_prod_serv = from(Endpoint.latency).filter(name == "/product/service").longAvg();

--- a/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/CountIndicatorTest.java
+++ b/oap-server/server-core/src/test/java/org/apache/skywalking/oap/server/core/analysis/indicator/CountIndicatorTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 /**
  * @author wusheng
  */
-public class SumIndicatorTest {
+public class CountIndicatorTest {
     @Test
     public void testEntranceCombine() {
-        SumIndicatorImpl impl = new SumIndicatorImpl();
+        CountIndicatorImpl impl = new CountIndicatorImpl();
         impl.combine(5);
         impl.combine(6);
         impl.combine(7);
@@ -40,12 +40,12 @@ public class SumIndicatorTest {
 
     @Test
     public void testSelfCombine() {
-        SumIndicatorImpl impl = new SumIndicatorImpl();
+        CountIndicatorImpl impl = new CountIndicatorImpl();
         impl.combine(5);
         impl.combine(6);
         impl.combine(7);
 
-        SumIndicatorImpl impl2 = new SumIndicatorImpl();
+        CountIndicatorImpl impl2 = new CountIndicatorImpl();
         impl2.combine(5);
         impl2.combine(6);
         impl2.combine(7);
@@ -57,7 +57,7 @@ public class SumIndicatorTest {
         Assert.assertEquals(36, impl.getValue());
     }
 
-    public class SumIndicatorImpl extends SumIndicator {
+    public class CountIndicatorImpl extends CountIndicator {
         @Override public String id() {
             return null;
         }

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricsServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricsServiceHandler.java
@@ -102,7 +102,7 @@ public class JVMMetricsServiceHandler extends JVMMetricsServiceGrpc.JVMMetricsSe
             serviceInstanceJVMMemory.setName(Const.EMPTY_STRING);
             serviceInstanceJVMMemory.setServiceInstanceId(serviceInstanceId);
             serviceInstanceJVMMemory.setServiceName(Const.EMPTY_STRING);
-            serviceInstanceJVMMemory.setHeap(memory.getIsHeap());
+            serviceInstanceJVMMemory.setHeapStatus(memory.getIsHeap());
             serviceInstanceJVMMemory.setInit(memory.getInit());
             serviceInstanceJVMMemory.setMax(memory.getMax());
             serviceInstanceJVMMemory.setUsed(memory.getUsed());


### PR DESCRIPTION
@hanahmily I want to info you, the `sum`func has been separated to `sum` and `count`. `sum` is for the aggregation of value field, `count` is for the aggregation
of row number.

@peng-yongsheng @hanahmily my generation codes are based on the following scripts, review this will be much easier. :)

FYI @ascrutae 

```

// All scope metric
all_p99 = from(All.latency).p99(10);
all_p95 = from(All.latency).p95(10);
all_p90 = from(All.latency).p90(10);
all_p75 = from(All.latency).p75(10);
all_p50 = from(All.latency).p50(10);
all_heatmap = from(All.latency).thermodynamic(100, 20);

// Service scope metric
service_resp_time = from(Service.latency).longAvg();
service_sla = from(Service.*).percent(status == true);
service_cpm = from(Service.*).cpm();
service_p99 = from(Service.latency).p99(10);
service_p95 = from(Service.latency).p95(10);
service_p90 = from(Service.latency).p90(10);
service_p75 = from(Service.latency).p75(10);
service_p50 = from(Service.latency).p50(10);

// Service relation scope metric for topology
service_relation_client_cpm = from(ServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).cpm();
service_relation_server_cpm = from(ServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
service_relation_client_call_sla = from(ServiceRelation.*).filter(detectPoint == DetectPoint.CLIENT).percent(status == true);
service_relation_server_call_sla = from(ServiceRelation.*).filter(detectPoint == DetectPoint.SERVER).percent(status == true);
service_relation_client_resp_time = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.CLIENT).longAvg();
service_relation_server_resp_time = from(ServiceRelation.latency).filter(detectPoint == DetectPoint.SERVER).longAvg();

// Service Instance Scope metric
serviceInstance_resp_time= from(ServiceInstance.latency).longAvg();
service_instance_cpm = from(ServiceInstance.*).cpm();

// Endpoint scope metric
endpoint_Avg = from(Endpoint.latency).longAvg();
endpoint_sla = from(Endpoint.*).percent(status == true);
endpoint_p99 = from(Endpoint.latency).p99(10);
endpoint_p95 = from(Endpoint.latency).p95(10);
endpoint_p90 = from(Endpoint.latency).p90(10);
endpoint_p75 = from(Endpoint.latency).p75(10);
endpoint_p50 = from(Endpoint.latency).p50(10);

// Endpoint relation scope metric
endpoint_relation_cpm = from(EndpointRelation.*).filter(detectPoint == DetectPoint.SERVER).cpm();
endpoint_relation_resp_time = from(EndpointRelation.rpcLatency).filter(detectPoint == DetectPoint.SERVER).longAvg();

// JVM instance metric
instance_jvm_cpu = from(ServiceInstanceJVMCPU.usePercent).doubleAvg();
instance_jvm_memory_heap = from(ServiceInstanceJVMMemory.max).filter(isHeap == true).longAvg();
instance_jvm_memory_noheap = from(ServiceInstanceJVMMemory.max).filter(isHeap == false).longAvg();
instance_jvm_young_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.NEW).longAvg();
instance_jvm_old_gc_time = from(ServiceInstanceJVMGC.time).filter(phrase == GCPhrase.OLD).longAvg();
instance_jvm_young_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.NEW).sum();
instance_jvm_old_gc_count = from(ServiceInstanceJVMGC.count).filter(phrase == GCPhrase.OLD).sum();
```