### PR TITLE
Make detect point consistency

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/EndpointInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/EndpointInventoryRegister.java
@@ -22,6 +22,7 @@ import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
 import org.apache.skywalking.oap.server.core.register.EndpointInventory;
 import org.apache.skywalking.oap.server.core.register.worker.InventoryProcess;
+import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.slf4j.*;
 
@@ -48,14 +49,14 @@ public class EndpointInventoryRegister implements IEndpointInventoryRegister {
         return cacheService;
     }
 
-    @Override public int getOrCreate(int serviceId, String endpointName, int detectPoint) {
+    @Override public int getOrCreate(int serviceId, String endpointName, DetectPoint detectPoint) {
         int endpointId = getCacheService().getEndpointId(serviceId, endpointName);
 
         if (endpointId == Const.NONE) {
             EndpointInventory endpointInventory = new EndpointInventory();
             endpointInventory.setServiceId(serviceId);
             endpointInventory.setName(endpointName);
-            endpointInventory.setDetectPoint(detectPoint);
+            endpointInventory.setDetectPoint(detectPoint.ordinal());
 
             long now = System.currentTimeMillis();
             endpointInventory.setRegisterTime(now);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IEndpointInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IEndpointInventoryRegister.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.register.service;
 
+import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
@@ -25,7 +26,7 @@ import org.apache.skywalking.oap.server.library.module.Service;
  */
 public interface IEndpointInventoryRegister extends Service {
 
-    int getOrCreate(int serviceId, String endpointName, int detectPoint);
+    int getOrCreate(int serviceId, String endpointName, DetectPoint detectPoint);
 
     int get(int serviceId, String endpointName);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DetectPoint.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DetectPoint.java
@@ -18,9 +18,37 @@
 
 package org.apache.skywalking.oap.server.core.source;
 
+import org.apache.skywalking.apm.network.language.agent.SpanType;
+
 /**
  * @author peng-yongsheng
  */
 public enum DetectPoint {
-    CLIENT, SERVER, PROXY
+    SERVER, CLIENT, PROXY, UNRECOGNIZED;
+
+    public static DetectPoint fromSpanType(SpanType spanType) {
+        switch (spanType) {
+            case Entry:
+                return DetectPoint.SERVER;
+            case Exit:
+                return DetectPoint.SERVER;
+            case UNRECOGNIZED:
+            case Local:
+            default:
+                return DetectPoint.UNRECOGNIZED;
+        }
+    }
+
+    public static DetectPoint fromMeshDetectPoint(org.apache.skywalking.apm.network.common.DetectPoint detectPoint) {
+        switch (detectPoint) {
+            case client:
+                return CLIENT;
+            case server:
+                return SERVER;
+            case proxy:
+            case UNRECOGNIZED:
+            default:
+                return UNRECOGNIZED;
+        }
+    }
 }

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
@@ -83,16 +83,9 @@ public class ServiceMeshMetricDataDecorator {
         String endpoint = origin.getEndpoint();
         if (destServiceId != Const.NONE) {
             DetectPoint point = origin.getDetectPoint();
-            /**
-             * Detect point matches {@link SpanType}, value options:
-             *
-             *     Entry = 0; Server side.
-             *     Exit = 1;  Client side
-             *     Local = 2; Never used.
-             *
-             */
-            int detectPointInt = DetectPoint.client.equals(point) ? 1 : 0;
-            endpointId = CoreRegisterLinker.getEndpointInventoryRegister().getOrCreate(destServiceId, endpoint, detectPointInt);
+
+            endpointId = CoreRegisterLinker.getEndpointInventoryRegister().getOrCreate(destServiceId, endpoint,
+                org.apache.skywalking.oap.server.core.source.DetectPoint.fromMeshDetectPoint(point));
             if (endpointId != Const.NONE) {
             } else {
                 isRegistered = false;

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/ServiceNameDiscoveryHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/ServiceNameDiscoveryHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.skywalking.apm.network.language.agent.*;
 import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.register.service.IEndpointInventoryRegister;
+import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 import org.slf4j.*;
@@ -48,8 +49,7 @@ public class ServiceNameDiscoveryHandler extends ServiceNameDiscoveryServiceGrpc
         for (ServiceNameElement serviceNameElement : serviceNameElementList) {
             int serviceId = serviceNameElement.getApplicationId();
             String endpointName = serviceNameElement.getServiceName();
-            int srcSpanType = serviceNameElement.getSrcSpanTypeValue();
-            int endpointId = inventoryService.getOrCreate(serviceId, endpointName, srcSpanType);
+            int endpointId = inventoryService.getOrCreate(serviceId, endpointName, DetectPoint.fromSpanType(serviceNameElement.getSrcSpanType()));
 
             if (endpointId != Const.NONE) {
                 ServiceNameMappingElement.Builder mappingElement = ServiceNameMappingElement.newBuilder();

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.trace.provider.parser.standard
 import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
 import org.apache.skywalking.oap.server.core.register.service.*;
+import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.util.StringUtils;
 import org.apache.skywalking.oap.server.receiver.trace.provider.parser.decorator.SpanDecorator;
@@ -88,7 +89,7 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
 
         if (standardBuilder.getOperationNameId() == 0) {
             String endpointName = StringUtils.isNotEmpty(standardBuilder.getOperationName()) ? standardBuilder.getOperationName() : Const.DOMAIN_OPERATION_NAME;
-            int endpointId = endpointInventoryRegister.getOrCreate(serviceId, endpointName, standardBuilder.getSpanTypeValue());
+            int endpointId = endpointInventoryRegister.getOrCreate(serviceId, endpointName, DetectPoint.fromSpanType(standardBuilder.getSpanType()));
 
             if (endpointId == 0) {
                 if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Make DetectPoint in Mesh gRPC protocol, DetectPoint in Source, and SpanSrcType convert to each other right. In old codes, enum SpanSrcType#Entry and DetectPoint#Server in Source have different enum value, but the current codes assume they are same which causes numberOfService incorrect.

![image](https://user-images.githubusercontent.com/5441976/46151173-c9bd9180-c2a0-11e8-8f18-a2635f7e9c47.png)
