### PR TITLE
Collector cluster list order doesn't work right

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cluster/RemoteInstance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/cluster/RemoteInstance.java
@@ -37,7 +37,7 @@ public class RemoteInstance implements Comparable<RemoteInstance> {
     }
 
     @Override public int compareTo(RemoteInstance o) {
-        return toString().compareTo(toString());
+        return toString().compareTo(o.toString());
     }
 
     @Override public String toString() {


### PR DESCRIPTION
The old `compareTo` method doesn't work right in **RemoteInstance**. Because of that, it makes the oap cluster list order not right.