### PR TITLE
The pattern in log4j2's config in incorrect.

### DIFF
--- a/oap-server/server-starter/src/main/assembly/log4j2.xml
+++ b/oap-server/server-starter/src/main/assembly/log4j2.xml
@@ -25,7 +25,7 @@
         <RollingFile name="RollingFile" fileName="${log-path}/skywalking-oap-server.log"
                      filePattern="${log-path}/skywalking-oap-server-%d{yyyy-MM-dd}-%i.log" >
             <PatternLayout>
-                <pattern>%d - %c -%-4r [%t] %-5p %x - %m%n</pattern>
+                <pattern>%d - %c - %L [%t] %-5p %x - %m%n</pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="102400KB" />


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#1926 
___
### Bug fix
- Bug description.
Log4j2's xml in assembly folder is different with resource folder, it lead the logs missing the line number.

- How to fix?
Synchronous configuration section.