### PR TITLE
Upgrade gRPC library.

### DIFF
--- a/apm-dist/release-docs/LICENSE
+++ b/apm-dist/release-docs/LICENSE
@@ -226,11 +226,13 @@ The following components are provided under the Apache License. See project link
 The text of each license is the standard Apache 2.0 license.
 
     raphw (byte-buddy) 1.9.2: http://bytebuddy.net/ , Apache 2.0
-    Google: grpc 1.10.0: https://grpc.io/ , Apache 2.0
-    Google: gprc-java 1.10.0: https://github.com/grpc/grpc-java, Apache 2.0
-    Google: guava 19.0: https://github.com/google/guava , Apache 2.0
+    Google: grpc 1.14.0: https://grpc.io/ , Apache 2.0
+    Google: grpc 1.15.1: https://grpc.io/ , Apache 2.0
+    Google: gprc-java 1.14.0: https://github.com/grpc/grpc-java, Apache 2.0
+    Google: gprc-java 1.15.1: https://github.com/grpc/grpc-java, Apache 2.0
+    Google: guava 20.0: https://github.com/google/guava , Apache 2.0
     Google: gson 2.8.1: https://github.com/google/gson , Apache 2.0
-    Google: opencensus-java 0.8.0: https://github.com/census-instrumentation/opencensus-java , Apache 2.0
+    Google: opencensus-java 0.12.3: https://github.com/census-instrumentation/opencensus-java , Apache 2.0
     Google: proto-google-common-protos 0.1.9: https://github.com/googleapis/googleapis , Apache 2.0
     Google: jsr305 3.0.0: http://central.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.0/jsr305-3.0.0.pom , Apache 2.0
     Elasticsearch BV (Elasticsearch) 6.3.2: https://www.elastic.co/products/elasticsearch , Apache 2.0

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -42,13 +42,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.9.0</log4j.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>20.0</guava.version>
         <snakeyaml.version>1.18</snakeyaml.version>
         <gson.version>2.8.1</gson.version>
         <graphql-java-tools.version>5.2.3</graphql-java-tools.version>
         <graphql-java.version>8.0</graphql-java.version>
         <zookeeper.version>3.4.10</zookeeper.version>
-        <grpc.version>1.10.0</grpc.version>
+        <grpc.version>1.15.1</grpc.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <jetty.version>9.4.2.v20170220</jetty.version>
         <lombok.version>1.18.0</lombok.version>


### PR DESCRIPTION
The gRPC new library fixed some core bugs. Upgrade to 1.15.1 in backend project.

1. core: fix memory leak when inbound message was not fully read (#4298). This mainly applies to custom message marshallers; it would be very rare for the protobuf marshaller.

1. netty: Client sends rst stream when server half-closes. This fixes a memory leak when server closes before client half closes (#4275)