### PR TITLE
fixed bug: multiple formatIndexName in forceUpdate method

### DIFF
--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClient.java
@@ -142,7 +142,6 @@ public class ElasticSearchClient implements Client {
     }
 
     public void forceUpdate(String indexName, String id, XContentBuilder source, long version) throws IOException {
-        indexName = formatIndexName(indexName);
         UpdateRequest request = prepareUpdate(indexName, id, source);
         request.version(version);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -150,7 +149,6 @@ public class ElasticSearchClient implements Client {
     }
 
     public void forceUpdate(String indexName, String id, XContentBuilder source) throws IOException {
-        indexName = formatIndexName(indexName);
         UpdateRequest request = prepareUpdate(indexName, id, source);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         client.update(request);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [+] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
  when I add namespace: test ,  the elaticSearch Client will update by find the test_test_indexName
- How to fix?
in forceUpdate delete the first line which format the indexName.
___
### New feature or improvement
- Describe the details and related test reports.
