### PR TITLE
add TiDB  storage configuration description.

### DIFF
--- a/docs/en/setup/backend/backend-storage.md
+++ b/docs/en/setup/backend/backend-storage.md
@@ -60,6 +60,17 @@ All connection related settings including link url, username and password
 are in `databsource-settings.properties`. 
 This setting file follow [HikariCP](https://github.com/brettwooldridge/HikariCP) connection pool document.
 
+## TiDB
+Currently tested in version 2.0.9.
+Active TiDB as storage, set storage provider to **mysql**. 
+
+```yaml
+storage:
+  mysql:
+```
+
+All connection related settings including link url, username and password
+are in `databsource-settings.properties`. And these settings can refer to the configuration of *MySQL* above.
 
 ## More storage solution extension
 Follow [Storage extension development guide](../../guides/storage-extention.md) 


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
I tested the colletor storage with TiDB(v2.0.9) in my local env as follows:
I used two PCs, an iMac (4 core, 16G Memory,1TB Storage), and another MacBook Pro (2 Core, 8G Memeroy, 250G SSD Storage).
And I installed a TIDB store on the iMac through the docker-compose[1] quick start, running Skywalking collector and a demo on the MacBook Pro.

[1  TiDB Docker Compose](https://pingcap.com/docs/op-guide/docker-compose/) 