### PR TITLE
Make endpoint and instance alarm active

### DIFF
--- a/docs/en/setup/backend/backend-alarm.md
+++ b/docs/en/setup/backend/backend-alarm.md
@@ -49,9 +49,18 @@ rules:
     count: 4
 ```
 
+## Default alarm rules
+We provided a default `alarm-setting.yml` in our distribution only for convenience, which including following rules
+1. Service average response time over 1s in last 3 minutes.
+1. Service success rate lower than 80% in last 2 minutes.
+1. Service 90% response time is lower than 1000ms in last 3 minutes
+1. Service Instance average response time over 1s in last 2 minutes.
+1. Endpoint average response time over 1s in last 2 minutes.
+ 
+
 
 ## List of all potential metric name
 The metric names are defined in official [OAL scripts](../../guides/backend-oal-scripts.md), right now 
-only metric from **Service** scope could be used in Alarm, we will extend in further versions. 
+metric from **Service**, **Service Instance**, **Endpoint** scopes could be used in Alarm, we will extend in further versions. 
 
 Submit issue or pull request if you want to support any other scope in alarm.

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmCore.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmCore.java
@@ -69,21 +69,25 @@ public class AlarmCore {
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
             try {
                 List<AlarmMessage> alarmMessageList = new ArrayList<>(30);
+                LocalDateTime checkTime = LocalDateTime.now();
+                int minutes = Minutes.minutesBetween(lastExecuteTime, checkTime).getMinutes();
+                boolean[] hasExecute = new boolean[] {false};
                 runningContext.values().forEach(ruleList -> ruleList.forEach(runningRule -> {
-                    LocalDateTime checkTime = LocalDateTime.now();
-                    int minutes = Minutes.minutesBetween(lastExecuteTime, checkTime).getMinutes();
                     if (minutes > 0) {
+                        hasExecute[0] = true;
                         runningRule.moveTo(checkTime);
                         /**
                          * Don't run in the first quarter per min, avoid to trigger false alarm.
                          */
                         if (checkTime.getSecondOfMinute() > 15) {
                             alarmMessageList.addAll(runningRule.check());
-                            // Set the last execute time, and make sure the second is `00`, such as: 18:30:00
-                            lastExecuteTime = checkTime.minusSeconds(checkTime.getSecondOfMinute());
                         }
                     }
                 }));
+                // Set the last execute time, and make sure the second is `00`, such as: 18:30:00
+                if (hasExecute[0]) {
+                    lastExecuteTime = checkTime.minusSeconds(checkTime.getSecondOfMinute());
+                }
 
                 if (alarmMessageList.size() > 0) {
                     allCallbacks.forEach(callback -> callback.doAlarm(alarmMessageList));

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandler.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/NotifyHandler.java
@@ -38,6 +38,10 @@ public class NotifyHandler implements IndicatorNotify {
         switch (meta.getScope()) {
             case Service:
                 break;
+            case ServiceInstance:
+                break;
+            case Endpoint:
+                break;
             default:
                 return;
         }

--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/RunningRule.java
@@ -118,14 +118,9 @@ public class RunningRule {
             Window window = windows.get(meta);
             if (window == null) {
                 window = new Window(period);
-                Window ifAbsent = windows.putIfAbsent(meta, window);
-                if (ifAbsent == null) {
-                    LocalDateTime timebucket = TIME_BUCKET_FORMATTER.parseLocalDateTime(indicator.getTimeBucket() + "");
-                    window.moveTo(timebucket);
-                } else {
-                    window = windows.get(meta);
-                }
-
+                LocalDateTime timebucket = TIME_BUCKET_FORMATTER.parseLocalDateTime(indicator.getTimeBucket() + "");
+                window.moveTo(timebucket);
+                windows.put(meta, window);
             }
 
             window.add(indicator);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmEntrance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/AlarmEntrance.java
@@ -54,7 +54,7 @@ public class AlarmEntrance {
 
         AlarmMeta alarmMeta = ((AlarmSupported)indicator).getAlarmMeta();
 
-        MetaInAlarm metaInAlarm = null;
+        MetaInAlarm metaInAlarm;
         switch (alarmMeta.getScope()) {
             case Service:
                 int serviceId = Integer.parseInt(alarmMeta.getId());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/EndpointMetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/EndpointMetaInAlarm.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.alarm;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.skywalking.oap.server.core.source.Scope;
+
+@Getter(AccessLevel.PUBLIC)
+@Setter(AccessLevel.PUBLIC)
+public class EndpointMetaInAlarm extends MetaInAlarm {
+    private String indicatorName;
+
+    private int id;
+    private String name;
+    private String[] tags;
+    private String[] properties;
+
+    @Override public Scope getScope() {
+        return Scope.Endpoint;
+    }
+
+    @Override public int getId0() {
+        return id;
+    }
+
+    @Override public int getId1() {
+        return 0;
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceInstanceMetaInAlarm.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/ServiceInstanceMetaInAlarm.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.alarm;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.skywalking.oap.server.core.source.Scope;
+
+@Getter(AccessLevel.PUBLIC)
+@Setter(AccessLevel.PUBLIC)
+public class ServiceInstanceMetaInAlarm extends MetaInAlarm {
+    private String indicatorName;
+
+    private int id;
+    private String name;
+    private String[] tags;
+    private String[] properties;
+
+    @Override public Scope getScope() {
+        return Scope.ServiceInstance;
+    }
+
+    @Override public int getId0() {
+        return id;
+    }
+
+    @Override public int getId1() {
+        return 0;
+    }
+}

--- a/oap-server/server-starter/src/main/assembly/alarm-settings.yml
+++ b/oap-server/server-starter/src/main/assembly/alarm-settings.yml
@@ -49,6 +49,7 @@ rules:
   service_instance_resp_time_rule:
     indicator-name: service_instance_resp_time
     op: ">"
+    threshold: 1000
     period: 10
     count: 2
     silence-period: 5

--- a/oap-server/server-starter/src/main/assembly/alarm-settings.yml
+++ b/oap-server/server-starter/src/main/assembly/alarm-settings.yml
@@ -36,7 +36,7 @@ rules:
     count: 2
     # How many times of checks, the alarm keeps silence after alarm triggered, default as same as period.
     silence-period: 3
-    message: Successful rate of service {name} is lower than 80% in last 2 minuts.
+    message: Successful rate of service {name} is lower than 80% in last 2 minutes.
   service_p90_sla_rule:
     # Indicator value need to be long, double or int
     indicator-name: service_p90
@@ -50,17 +50,17 @@ rules:
     indicator-name: service_instance_resp_time
     op: ">"
     period: 10
-    count: 3
+    count: 2
     silence-period: 5
-    message: Response time of service instance {name} is more than 1000ms in last 3 minutes.
-  endpoint_sla_rule:
-    indicator-name: endpoint_sla
-    op: "<"
-    threshold: 8000
+    message: Response time of service instance {name} is more than 1000ms in last 2 minutes.
+  endpoint_avg_rule:
+    indicator-name: endpoint_avg
+    op: ">"
+    threshold: 1000
     period: 10
     count: 2
-    silence-period: 3
-    message: Successful rate of endpoint {name} is lower than 80% in last 2 minuts.
+    silence-period: 5
+    message: Response time of endpoint {name} is more than 1000ms in last 2 minutes.
 
 webhooks:
 #  - http://127.0.0.1/notify/

--- a/oap-server/server-starter/src/main/assembly/alarm-settings.yml
+++ b/oap-server/server-starter/src/main/assembly/alarm-settings.yml
@@ -24,28 +24,43 @@ rules:
     period: 10
     count: 3
     silence-period: 5
-    message: Response time of service {name} is more than 2000ms.
+    message: Response time of service {name} is more than 1000ms in last 3 minutes.
   service_sla_rule:
     # Indicator value need to be long, double or int
     indicator-name: service_sla
     op: "<"
-    threshold: 80
+    threshold: 8000
     # The length of time to evaluate the metric
     period: 10
     # How many times after the metric match the condition, will trigger alarm
     count: 2
     # How many times of checks, the alarm keeps silence after alarm triggered, default as same as period.
     silence-period: 3
-    message: Successful rate of service {name} is lower than 80%
+    message: Successful rate of service {name} is lower than 80% in last 2 minuts.
   service_p90_sla_rule:
     # Indicator value need to be long, double or int
-    indicator-name: service_sla
+    indicator-name: service_p90
     op: ">"
     threshold: 1000
     period: 10
     count: 3
     silence-period: 5
-    message: 90% response time of service {name} is lower than 80%
+    message: 90% response time of service {name} is lower than 1000ms in last 3 minutes
+  service_instance_resp_time_rule:
+    indicator-name: service_instance_resp_time
+    op: ">"
+    period: 10
+    count: 3
+    silence-period: 5
+    message: Response time of service instance {name} is more than 1000ms in last 3 minutes.
+  endpoint_sla_rule:
+    indicator-name: endpoint_sla
+    op: "<"
+    threshold: 8000
+    period: 10
+    count: 2
+    silence-period: 3
+    message: Successful rate of endpoint {name} is lower than 80% in last 2 minuts.
 
 webhooks:
 #  - http://127.0.0.1/notify/


### PR DESCRIPTION
Now, you could have service, service instance and endpoint alarm rules.

Also in this pull request, do following adjustments
1. Add following rules
```
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# Sample alarm rules.
rules:
  # Rule unique name, must be ended with `_rule`.
  service_resp_time_rule:
    indicator-name: service_resp_time
    op: ">"
    threshold: 1000
    period: 10
    count: 3
    silence-period: 5
    message: Response time of service {name} is more than 1000ms in last 3 minutes.
  service_sla_rule:
    # Indicator value need to be long, double or int
    indicator-name: service_sla
    op: "<"
    threshold: 8000
    # The length of time to evaluate the metric
    period: 10
    # How many times after the metric match the condition, will trigger alarm
    count: 2
    # How many times of checks, the alarm keeps silence after alarm triggered, default as same as period.
    silence-period: 3
    message: Successful rate of service {name} is lower than 80% in last 2 minutes.
  service_p90_sla_rule:
    # Indicator value need to be long, double or int
    indicator-name: service_p90
    op: ">"
    threshold: 1000
    period: 10
    count: 3
    silence-period: 5
    message: 90% response time of service {name} is lower than 1000ms in last 3 minutes
  service_instance_resp_time_rule:
    indicator-name: service_instance_resp_time
    op: ">"
    threshold: 1000
    period: 10
    count: 2
    silence-period: 5
    message: Response time of service instance {name} is more than 1000ms in last 2 minutes.
  endpoint_avg_rule:
    indicator-name: endpoint_avg
    op: ">"
    threshold: 1000
    period: 10
    count: 2
    silence-period: 5
    message: Response time of endpoint {name} is more than 1000ms in last 2 minutes.

webhooks:
#  - http://127.0.0.1/notify/
#  - http://127.0.0.1/go-wechat/
```

2. **Fix alarm check bug**. The old core can't work on multiple rules as expected, because of check timer's `lastExecuteTime` update mechanism. 