### PR TITLE
Move node type from network address to service level[Need storage module update]

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
@@ -20,7 +20,6 @@ package org.apache.skywalking.oap.server.core.query;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.skywalking.apm.network.language.agent.SpanLayer;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.*;
 import org.apache.skywalking.oap.server.core.query.entity.*;
@@ -69,8 +68,8 @@ public class MetadataQueryService implements org.apache.skywalking.oap.server.li
         clusterBrief.setNumOfService(getMetadataQueryDAO().numOfService(startTimestamp, endTimestamp));
         clusterBrief.setNumOfEndpoint(getMetadataQueryDAO().numOfEndpoint(startTimestamp, endTimestamp));
         clusterBrief.setNumOfDatabase(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, NodeType.Database.value()));
-        clusterBrief.setNumOfCache(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp,  NodeType.Cache.value()));
-        clusterBrief.setNumOfMQ(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp,  NodeType.MQ.value()));
+        clusterBrief.setNumOfCache(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, NodeType.Cache.value()));
+        clusterBrief.setNumOfMQ(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, NodeType.MQ.value()));
         return clusterBrief;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/MetadataQueryService.java
@@ -24,7 +24,7 @@ import org.apache.skywalking.apm.network.language.agent.SpanLayer;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.*;
 import org.apache.skywalking.oap.server.core.query.entity.*;
-import org.apache.skywalking.oap.server.core.register.EndpointInventory;
+import org.apache.skywalking.oap.server.core.register.*;
 import org.apache.skywalking.oap.server.core.storage.StorageModule;
 import org.apache.skywalking.oap.server.core.storage.query.IMetadataQueryDAO;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -68,9 +68,9 @@ public class MetadataQueryService implements org.apache.skywalking.oap.server.li
         ClusterBrief clusterBrief = new ClusterBrief();
         clusterBrief.setNumOfService(getMetadataQueryDAO().numOfService(startTimestamp, endTimestamp));
         clusterBrief.setNumOfEndpoint(getMetadataQueryDAO().numOfEndpoint(startTimestamp, endTimestamp));
-        clusterBrief.setNumOfDatabase(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, SpanLayer.Database_VALUE));
-        clusterBrief.setNumOfCache(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, SpanLayer.Cache_VALUE));
-        clusterBrief.setNumOfMQ(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, SpanLayer.MQ_VALUE));
+        clusterBrief.setNumOfDatabase(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp, NodeType.Database.value()));
+        clusterBrief.setNumOfCache(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp,  NodeType.Cache.value()));
+        clusterBrief.setNumOfMQ(getMetadataQueryDAO().numOfConjectural(startTimestamp, endTimestamp,  NodeType.MQ.value()));
         return clusterBrief;
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
@@ -40,10 +40,10 @@ public class NetworkAddressInventory extends RegisterSource {
     public static final String MODEL_NAME = "network_address_inventory";
 
     private static final String NAME = "name";
-    public static final String SRC_LAYER = "src_layer";
+    public static final String NODE_TYPE = "node_type";
 
     @Setter @Getter @Column(columnName = NAME, matchQuery = true) private String name = Const.EMPTY_STRING;
-    @Setter @Getter @Column(columnName = SRC_LAYER) private int srcLayer;
+    @Setter @Getter @Column(columnName = NODE_TYPE) private int nodeType;
 
     public static String buildId(String networkAddress) {
         return networkAddress;
@@ -77,13 +77,13 @@ public class NetworkAddressInventory extends RegisterSource {
     @Override public void combine(RegisterSource registerSource) {
         super.combine(registerSource);
         NetworkAddressInventory inventory = (NetworkAddressInventory)registerSource;
-        setSrcLayer(inventory.srcLayer);
+        setNodeType(inventory.nodeType);
     }
 
     @Override public RemoteData.Builder serialize() {
         RemoteData.Builder remoteBuilder = RemoteData.newBuilder();
         remoteBuilder.addDataIntegers(getSequence());
-        remoteBuilder.addDataIntegers(getSrcLayer());
+        remoteBuilder.addDataIntegers(getNodeType());
 
         remoteBuilder.addDataLongs(getRegisterTime());
         remoteBuilder.addDataLongs(getHeartbeatTime());
@@ -94,7 +94,7 @@ public class NetworkAddressInventory extends RegisterSource {
 
     @Override public void deserialize(RemoteData remoteData) {
         setSequence(remoteData.getDataIntegers(0));
-        setSrcLayer(remoteData.getDataIntegers(1));
+        setNodeType(remoteData.getDataIntegers(1));
 
         setRegisterTime(remoteData.getDataLongs(0));
         setHeartbeatTime(remoteData.getDataLongs(1));
@@ -112,7 +112,7 @@ public class NetworkAddressInventory extends RegisterSource {
             NetworkAddressInventory inventory = new NetworkAddressInventory();
             inventory.setSequence((Integer)dbMap.get(SEQUENCE));
             inventory.setName((String)dbMap.get(NAME));
-            inventory.setSrcLayer((Integer)dbMap.get(SRC_LAYER));
+            inventory.setNodeType((Integer)dbMap.get(NODE_TYPE));
             inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
             inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
             return inventory;
@@ -122,7 +122,7 @@ public class NetworkAddressInventory extends RegisterSource {
             Map<String, Object> map = new HashMap<>();
             map.put(SEQUENCE, storageData.getSequence());
             map.put(NAME, storageData.getName());
-            map.put(SRC_LAYER, storageData.getSrcLayer());
+            map.put(NODE_TYPE, storageData.getNodeType());
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
             return map;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
@@ -43,7 +43,15 @@ public class NetworkAddressInventory extends RegisterSource {
     public static final String NODE_TYPE = "node_type";
 
     @Setter @Getter @Column(columnName = NAME, matchQuery = true) private String name = Const.EMPTY_STRING;
-    @Setter @Getter @Column(columnName = NODE_TYPE) private int nodeType;
+    @Setter(AccessLevel.PRIVATE) @Getter(AccessLevel.PRIVATE) @Column(columnName = NODE_TYPE) private int nodeType;
+
+    public void setNetworkAddressNodeType(NodeType nodeType) {
+        this.nodeType = nodeType.value();
+    }
+
+    public NodeType getNetworkAddressNodeType() {
+        return NodeType.get(this.nodeType);
+    }
 
     public static String buildId(String networkAddress) {
         return networkAddress;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NodeType.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NodeType.java
@@ -85,4 +85,14 @@ public enum NodeType {
                 throw new UnexpectedException("Unknown NodeType value");
         }
     }
+
+    /**
+     * Right now, spanLayerValue is exact same as NodeType value.
+     *
+     * @param spanLayerValue
+     * @return
+     */
+    public static NodeType fromSpanLayerValue(int spanLayerValue) {
+        return get(spanLayerValue);
+    }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NodeType.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NodeType.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core.register;
+
+import org.apache.skywalking.oap.server.core.UnexpectedException;
+
+/**
+ * Node type describe which kind of node of Service or Network address represents to.
+ *
+ * The value comes from 'org.apache.skywalking.apm.network.language.agent.SpanLayer' at first place, but most likely it
+ * will extend and be used directly from different sources, such as Mesh.
+ *
+ * @author wusheng
+ */
+public enum NodeType {
+    /**
+     * <code>Unknown = 0;</code>
+     */
+    Unknown(0),
+    /**
+     * <code>Database = 1;</code>
+     */
+    Database(1),
+    /**
+     * <code>RPCFramework = 2;</code>
+     */
+    RPCFramework(2),
+    /**
+     * <code>Http = 3;</code>
+     */
+    Http(3),
+    /**
+     * <code>MQ = 4;</code>
+     */
+    MQ(4),
+    /**
+     * <code>Cache = 5;</code>
+     */
+    Cache(5),
+    UNRECOGNIZED(-1);
+
+    private final int value;
+
+    NodeType(int value) {
+        this.value = value;
+    }
+
+    public int value() {
+        return value;
+    }
+
+    public static NodeType get(int value) {
+        switch (value) {
+            case 0:
+                return Unknown;
+            case 1:
+                return Database;
+            case 2:
+                return RPCFramework;
+            case 3:
+                return Http;
+            case 4:
+                return MQ;
+            case 5:
+                return Cache;
+            case -1:
+                return UNRECOGNIZED;
+            default:
+                throw new UnexpectedException("Unknown NodeType value");
+        }
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -50,9 +50,14 @@ public class ServiceInventory extends RegisterSource {
     @Setter @Getter @Column(columnName = NAME, matchQuery = true) private String name = Const.EMPTY_STRING;
     @Setter @Getter @Column(columnName = IS_ADDRESS) private int isAddress;
     @Setter @Getter @Column(columnName = ADDRESS_ID) private int addressId;
-    @Setter @Getter @Column(columnName = NODE_TYPE) private int nodeType;
+    @Setter(AccessLevel.PRIVATE) @Getter(AccessLevel.PRIVATE) @Column(columnName = NODE_TYPE) private int nodeType;
     @Setter @Getter @Column(columnName = MAPPING_SERVICE_ID) private int mappingServiceId;
     @Setter @Getter @Column(columnName = MAPPING_LAST_UPDATE_TIME) private long mappingLastUpdateTime;
+
+
+    public NodeType getServiceNodeType() {
+        return NodeType.get(this.nodeType);
+    }
 
     public static String buildId(String serviceName) {
         return serviceName + Const.ID_SPLIT + BooleanUtils.FALSE + Const.ID_SPLIT + Const.NONE;
@@ -60,6 +65,10 @@ public class ServiceInventory extends RegisterSource {
 
     public static String buildId(int addressId) {
         return BooleanUtils.TRUE + Const.ID_SPLIT + addressId;
+    }
+
+    public void setServiceNodeType(NodeType nodeType){
+        this.nodeType = nodeType.value();
     }
 
     @Override public String id() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -157,6 +157,7 @@ public class ServiceInventory extends RegisterSource {
     @Override public void combine(RegisterSource registerSource) {
         super.combine(registerSource);
         ServiceInventory serviceInventory = (ServiceInventory)registerSource;
+        nodeType = serviceInventory.nodeType;
         if (Const.NONE != serviceInventory.getMappingServiceId() && serviceInventory.getMappingLastUpdateTime() >= this.getMappingLastUpdateTime()) {
             this.mappingServiceId = serviceInventory.getMappingServiceId();
             this.mappingLastUpdateTime = serviceInventory.getMappingLastUpdateTime();

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -43,12 +43,14 @@ public class ServiceInventory extends RegisterSource {
     public static final String NAME = "name";
     public static final String IS_ADDRESS = "is_address";
     private static final String ADDRESS_ID = "address_id";
+    public static final String NODE_TYPE = "node_type";
     public static final String MAPPING_SERVICE_ID = "mapping_service_id";
     public static final String MAPPING_LAST_UPDATE_TIME = "mapping_last_update_time";
 
     @Setter @Getter @Column(columnName = NAME, matchQuery = true) private String name = Const.EMPTY_STRING;
     @Setter @Getter @Column(columnName = IS_ADDRESS) private int isAddress;
     @Setter @Getter @Column(columnName = ADDRESS_ID) private int addressId;
+    @Setter @Getter @Column(columnName = NODE_TYPE) private int nodeType;
     @Setter @Getter @Column(columnName = MAPPING_SERVICE_ID) private int mappingServiceId;
     @Setter @Getter @Column(columnName = MAPPING_LAST_UPDATE_TIME) private long mappingLastUpdateTime;
 
@@ -83,6 +85,7 @@ public class ServiceInventory extends RegisterSource {
         inventory.setHeartbeatTime(getHeartbeatTime());
         inventory.setName(name);
         inventory.setIsAddress(isAddress);
+        inventory.setNodeType(nodeType);
         inventory.setAddressId(addressId);
         inventory.setMappingLastUpdateTime(mappingLastUpdateTime);
         inventory.setMappingServiceId(mappingServiceId);
@@ -115,6 +118,7 @@ public class ServiceInventory extends RegisterSource {
         remoteBuilder.addDataIntegers(isAddress);
         remoteBuilder.addDataIntegers(addressId);
         remoteBuilder.addDataIntegers(mappingServiceId);
+        remoteBuilder.addDataIntegers(nodeType);
 
         remoteBuilder.addDataLongs(getRegisterTime());
         remoteBuilder.addDataLongs(getHeartbeatTime());
@@ -129,6 +133,7 @@ public class ServiceInventory extends RegisterSource {
         setIsAddress(remoteData.getDataIntegers(1));
         setAddressId(remoteData.getDataIntegers(2));
         setMappingServiceId(remoteData.getDataIntegers(3));
+        setNodeType(remoteData.getDataIntegers(4));
 
         setRegisterTime(remoteData.getDataLongs(0));
         setHeartbeatTime(remoteData.getDataLongs(1));
@@ -159,6 +164,7 @@ public class ServiceInventory extends RegisterSource {
             inventory.setMappingServiceId((Integer)dbMap.get(MAPPING_SERVICE_ID));
             inventory.setName((String)dbMap.get(NAME));
             inventory.setAddressId((Integer)dbMap.get(ADDRESS_ID));
+            inventory.setNodeType((Integer)dbMap.get(NODE_TYPE));
             inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
             inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
             inventory.setMappingLastUpdateTime((Long)dbMap.get(MAPPING_LAST_UPDATE_TIME));
@@ -172,6 +178,7 @@ public class ServiceInventory extends RegisterSource {
             map.put(MAPPING_SERVICE_ID, storageData.getMappingServiceId());
             map.put(NAME, storageData.getName());
             map.put(ADDRESS_ID, storageData.getAddressId());
+            map.put(NODE_TYPE, storageData.getNodeType());
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
             map.put(MAPPING_LAST_UPDATE_TIME, storageData.getMappingLastUpdateTime());

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -54,7 +54,6 @@ public class ServiceInventory extends RegisterSource {
     @Setter @Getter @Column(columnName = MAPPING_SERVICE_ID) private int mappingServiceId;
     @Setter @Getter @Column(columnName = MAPPING_LAST_UPDATE_TIME) private long mappingLastUpdateTime;
 
-
     public NodeType getServiceNodeType() {
         return NodeType.get(this.nodeType);
     }
@@ -67,7 +66,7 @@ public class ServiceInventory extends RegisterSource {
         return BooleanUtils.TRUE + Const.ID_SPLIT + addressId;
     }
 
-    public void setServiceNodeType(NodeType nodeType){
+    public void setServiceNodeType(NodeType nodeType) {
         this.nodeType = nodeType.value();
     }
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/INetworkAddressInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/INetworkAddressInventoryRegister.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.register.service;
 
+import org.apache.skywalking.oap.server.core.register.NodeType;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
@@ -30,5 +31,5 @@ public interface INetworkAddressInventoryRegister extends Service {
 
     void heartbeat(int addressId, long heartBeatTime);
 
-    void update(int addressId, int srcLayer);
+    void update(int addressId, NodeType nodeType);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
@@ -126,7 +126,7 @@ public class NetworkAddressInventoryRegister implements INetworkAddressInventory
             InventoryProcess.INSTANCE.in(newNetworkAddress);
         }
 
-        ServiceInventory newServiceInventory = getServiceInventoryCache().get(getServiceInventoryCache().getServiceId(networkAddress.id()));
+        ServiceInventory newServiceInventory = getServiceInventoryCache().get(getServiceInventoryCache().getServiceId(networkAddress.getSequence()));
         if (!this.compare(newServiceInventory, nodeType)) {
             newServiceInventory.setServiceNodeType(nodeType);
             newServiceInventory.setHeartbeatTime(System.currentTimeMillis());
@@ -135,16 +135,16 @@ public class NetworkAddressInventoryRegister implements INetworkAddressInventory
         }
     }
 
-    private boolean compare(NetworkAddressInventory newNetworkAddress, NodeType srcLayer) {
+    private boolean compare(NetworkAddressInventory newNetworkAddress, NodeType nodeType) {
         if (Objects.nonNull(newNetworkAddress)) {
-            return srcLayer == newNetworkAddress.getNetworkAddressNodeType();
+            return nodeType == newNetworkAddress.getNetworkAddressNodeType();
         }
         return true;
     }
 
-    private boolean compare(ServiceInventory newServiceInventory, NodeType srcLayer) {
+    private boolean compare(ServiceInventory newServiceInventory, NodeType nodeType) {
         if (Objects.nonNull(newServiceInventory)) {
-            return srcLayer == newServiceInventory.getServiceNodeType();
+            return nodeType == newServiceInventory.getServiceNodeType();
         }
         return true;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/NetworkAddressInventoryRegister.java
@@ -115,27 +115,36 @@ public class NetworkAddressInventoryRegister implements INetworkAddressInventory
         }
     }
 
-    @Override public void update(int addressId, int nodeType) {
-        if (!this.compare(addressId, nodeType)) {
+    @Override public void update(int addressId, NodeType nodeType) {
+        NetworkAddressInventory networkAddress = getNetworkAddressInventoryCache().get(addressId);
+
+        if (!this.compare(networkAddress, nodeType)) {
             NetworkAddressInventory newNetworkAddress = getNetworkAddressInventoryCache().get(addressId);
-            newNetworkAddress.setNodeType(nodeType);
+            newNetworkAddress.setNetworkAddressNodeType(nodeType);
             newNetworkAddress.setHeartbeatTime(System.currentTimeMillis());
 
             InventoryProcess.INSTANCE.in(newNetworkAddress);
+        }
 
-            ServiceInventory newServiceInventory = getServiceInventoryCache().get(getServiceInventoryCache().getServiceId(newNetworkAddress.id()));
-            newServiceInventory.setNodeType(nodeType);
+        ServiceInventory newServiceInventory = getServiceInventoryCache().get(getServiceInventoryCache().getServiceId(networkAddress.id()));
+        if (!this.compare(newServiceInventory, nodeType)) {
+            newServiceInventory.setServiceNodeType(nodeType);
             newServiceInventory.setHeartbeatTime(System.currentTimeMillis());
 
             InventoryProcess.INSTANCE.in(newServiceInventory);
         }
     }
 
-    private boolean compare(int addressId, int srcLayer) {
-        NetworkAddressInventory networkAddress = getNetworkAddressInventoryCache().get(addressId);
+    private boolean compare(NetworkAddressInventory newNetworkAddress, NodeType srcLayer) {
+        if (Objects.nonNull(newNetworkAddress)) {
+            return srcLayer == newNetworkAddress.getNetworkAddressNodeType();
+        }
+        return true;
+    }
 
-        if (Objects.nonNull(networkAddress)) {
-            return srcLayer == networkAddress.getNodeType();
+    private boolean compare(ServiceInventory newServiceInventory, NodeType srcLayer) {
+        if (Objects.nonNull(newServiceInventory)) {
+            return srcLayer == newServiceInventory.getServiceNodeType();
         }
         return true;
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetadataQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/IMetadataQueryDAO.java
@@ -32,7 +32,7 @@ public interface IMetadataQueryDAO extends DAO {
 
     int numOfEndpoint(final long startTimestamp, final long endTimestamp) throws IOException;
 
-    int numOfConjectural(final long startTimestamp, final long endTimestamp, final int srcLayer) throws IOException;
+    int numOfConjectural(final long startTimestamp, final long endTimestamp, final int nodeTypeValue) throws IOException;
 
     List<Service> getAllServices(final long startTimestamp, final long endTimestamp) throws IOException;
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
@@ -81,8 +81,8 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
                 standardBuilder.setPeerId(peerId);
                 standardBuilder.setPeer(Const.EMPTY_STRING);
 
-                int spanLayer = standardBuilder.getSpanLayerValue();
-                networkAddressInventoryRegister.update(peerId, spanLayer);
+                int nodeType = standardBuilder.getSpanLayerValue();
+                networkAddressInventoryRegister.update(peerId, nodeType);
             }
         }
 

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.receiver.trace.provider.parser.standard
 import com.google.common.base.Strings;
 import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
+import org.apache.skywalking.oap.server.core.register.NodeType;
 import org.apache.skywalking.oap.server.core.register.service.*;
 import org.apache.skywalking.oap.server.core.source.DetectPoint;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
@@ -81,8 +82,8 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
                 standardBuilder.setPeerId(peerId);
                 standardBuilder.setPeer(Const.EMPTY_STRING);
 
-                int nodeType = standardBuilder.getSpanLayerValue();
-                networkAddressInventoryRegister.update(peerId, nodeType);
+                int spanLayerValue = standardBuilder.getSpanLayerValue();
+                networkAddressInventoryRegister.update(peerId, NodeType.fromSpanLayerValue(spanLayerValue));
             }
         }
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -75,10 +75,10 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
     @Override public int numOfConjectural(long startTimestamp, long endTimestamp, int nodeTypeValue) throws IOException {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
 
-        sourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.NODE_TYPE, nodeTypeValue));
+        sourceBuilder.query(QueryBuilders.termQuery(ServiceInventory.NODE_TYPE, nodeTypeValue));
         sourceBuilder.size(0);
 
-        SearchResponse response = getClient().search(NetworkAddressInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
 
         return (int)response.getHits().getTotalHits();
     }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -75,7 +75,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
     @Override public int numOfConjectural(long startTimestamp, long endTimestamp, int srcLayer) throws IOException {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
 
-        sourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.SRC_LAYER, srcLayer));
+        sourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.NODE_TYPE, srcLayer));
         sourceBuilder.size(0);
 
         SearchResponse response = getClient().search(NetworkAddressInventory.MODEL_NAME, sourceBuilder);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -72,10 +72,10 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         return (int)response.getHits().getTotalHits();
     }
 
-    @Override public int numOfConjectural(long startTimestamp, long endTimestamp, int srcLayer) throws IOException {
+    @Override public int numOfConjectural(long startTimestamp, long endTimestamp, int nodeTypeValue) throws IOException {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
 
-        sourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.NODE_TYPE, srcLayer));
+        sourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.NODE_TYPE, nodeTypeValue));
         sourceBuilder.size(0);
 
         SearchResponse response = getClient().search(NetworkAddressInventory.MODEL_NAME, sourceBuilder);

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -81,8 +81,8 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
         int nodeTypeValue) throws IOException {
         StringBuilder sql = new StringBuilder();
         List<Object> condition = new ArrayList<>(5);
-        sql.append("select count(*) num from ").append(NetworkAddressInventory.MODEL_NAME).append(" where ");
-        sql.append(NetworkAddressInventory.NODE_TYPE).append("=?");
+        sql.append("select count(*) num from ").append(ServiceInventory.MODEL_NAME).append(" where ");
+        sql.append(ServiceInventory.NODE_TYPE).append("=?");
         condition.add(nodeTypeValue);
 
         try (Connection connection = h2Client.getConnection()) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -78,12 +78,12 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
     }
 
     @Override public int numOfConjectural(long startTimestamp, long endTimestamp,
-        int srcLayer) throws IOException {
+        int nodeTypeValue) throws IOException {
         StringBuilder sql = new StringBuilder();
         List<Object> condition = new ArrayList<>(5);
         sql.append("select count(*) num from ").append(NetworkAddressInventory.MODEL_NAME).append(" where ");
         sql.append(NetworkAddressInventory.NODE_TYPE).append("=?");
-        condition.add(srcLayer);
+        condition.add(nodeTypeValue);
 
         try (Connection connection = h2Client.getConnection()) {
             try (ResultSet resultSet = h2Client.executeQuery(connection, sql.toString(), condition.toArray(new Object[0]))) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2MetadataQueryDAO.java
@@ -82,7 +82,7 @@ public class H2MetadataQueryDAO implements IMetadataQueryDAO {
         StringBuilder sql = new StringBuilder();
         List<Object> condition = new ArrayList<>(5);
         sql.append("select count(*) num from ").append(NetworkAddressInventory.MODEL_NAME).append(" where ");
-        sql.append(NetworkAddressInventory.SRC_LAYER).append("=?");
+        sql.append(NetworkAddressInventory.NODE_TYPE).append("=?");
         condition.add(srcLayer);
 
         try (Connection connection = h2Client.getConnection()) {


### PR DESCRIPTION
Update in this pull request

1. Rename `src_layer` to `node_type` for NetworkAddressInventory. **Break change**, need discussion. Is this acceptable? @peng-yongsheng It will benefit for long term.
1. Add `node_type` for ServiceInventory.
1. Add `NodeType` for backend code use. `spanLayer` would not be used in backend codes, except the trace analysis. We need to do more refactor to avoid using enum value of protocol level in our storage.
