### PR TITLE
Update How-to-release.md

### DIFF
--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -87,7 +87,7 @@ with .asc, .sha512.
     * Package name: apache-skywalking-incubating-x.y.z.tar.gz, apache-skywalking-incubating-x.y.z.zip
     * See Section "Find and download distribution in Apache Nexus Staging repositories" for more details
     * Create .sha512 package: `shasum -a 512 file > file.sha512`
-1. Upload gpg public key, named [KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS)
+1. Add your gpg public key into the [KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS) file. **Don't override the existing files.**
 
 ## Make the internal announcements
 Send an announcement mail in dev mail list.

--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -87,7 +87,7 @@ with .asc, .sha512.
     * Package name: apache-skywalking-incubating-x.y.z.tar.gz, apache-skywalking-incubating-x.y.z.zip
     * See Section "Find and download distribution in Apache Nexus Staging repositories" for more details
     * Create .sha512 package: `shasum -a 512 file > file.sha512`
-1. Add your gpg public key into the [KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS) file. **Don't override the existing files.**
+1. Add your gpg public key into the [KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS) file. **Don't override the existing file.**
 
 ## Make the internal announcements
 Send an announcement mail in dev mail list.

--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -87,7 +87,7 @@ with .asc, .sha512.
     * Package name: apache-skywalking-incubating-x.y.z.tar.gz, apache-skywalking-incubating-x.y.z.zip
     * See Section "Find and download distribution in Apache Nexus Staging repositories" for more details
     * Create .sha512 package: `shasum -a 512 file > file.sha512`
-1. Upload gpg public key, named KEY
+1. Upload gpg public key, named KEYS
 
 ## Make the internal announcements
 Send an announcement mail in dev mail list.

--- a/docs/en/guides/How-to-release.md
+++ b/docs/en/guides/How-to-release.md
@@ -87,7 +87,7 @@ with .asc, .sha512.
     * Package name: apache-skywalking-incubating-x.y.z.tar.gz, apache-skywalking-incubating-x.y.z.zip
     * See Section "Find and download distribution in Apache Nexus Staging repositories" for more details
     * Create .sha512 package: `shasum -a 512 file > file.sha512`
-1. Upload gpg public key, named KEYS
+1. Upload gpg public key, named [KEYS](https://dist.apache.org/repos/dist/release/incubator/skywalking/KEYS)
 
 ## Make the internal announcements
 Send an announcement mail in dev mail list.


### PR DESCRIPTION
The public gpg file name should be KEYS, not KEY. It will contains other PMCs public key in this file after you export from the gpg tools.