### PR TITLE
Provide two start up modes and documents.

### DIFF
--- a/apm-dist/bin/oapServiceNoInit.bat
+++ b/apm-dist/bin/oapServiceNoInit.bat
@@ -1,0 +1,37 @@
+@REM
+@REM  Licensed to the Apache Software Foundation (ASF) under one or more
+@REM  contributor license agreements.  See the NOTICE file distributed with
+@REM  this work for additional information regarding copyright ownership.
+@REM  The ASF licenses this file to You under the Apache License, Version 2.0
+@REM  (the "License"); you may not use this file except in compliance with
+@REM  the License.  You may obtain a copy of the License at
+@REM
+@REM      http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM  Unless required by applicable law or agreed to in writing, software
+@REM  distributed under the License is distributed on an "AS IS" BASIS,
+@REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM  See the License for the specific language governing permissions and
+@REM  limitations under the License.
+
+@echo off
+
+setlocal
+set OAP_PROCESS_TITLE=Skywalking-Collector
+set OAP_HOME=%~dp0%..
+set OAP_OPTS="-Xms256M -Xmx512M -Doap.logDir=%OAP_HOME%\logs"
+
+set CLASSPATH=%OAP_HOME%\config;.;
+set CLASSPATH=%OAP_HOME%\oap-libs\*;%CLASSPATH%
+
+if defined JAVA_HOME (
+ set _EXECJAVA="%JAVA_HOME%\bin\java"
+)
+
+if not defined JAVA_HOME (
+ echo "JAVA_HOME not set."
+ set _EXECJAVA=java
+)
+
+start "%OAP_PROCESS_TITLE%" %_EXECJAVA% "%OAP_OPTS%" -cp "%CLASSPATH%" -Dmode=no-init org.apache.skywalking.oap.server.starter.OAPServerStartUp
+endlocal

--- a/apm-dist/bin/oapServiceNoInit.sh
+++ b/apm-dist/bin/oapServiceNoInit.sh
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env sh
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+[ -z "$OAP_HOME" ] && OAP_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+OAP_LOG_DIR="${OAP_HOME}/logs"
+JAVA_OPTS=" -Xms256M -Xmx512M"
+
+if [ ! -d "${OAP_HOME}/logs" ]; then
+    mkdir -p "${OAP_LOG_DIR}"
+fi
+
+_RUNJAVA=${JAVA_HOME}/bin/java
+[ -z "$JAVA_HOME" ] && _RUNJAVA=java
+
+CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+for i in "$OAP_HOME"/oap-libs/*.jar
+do
+    CLASSPATH="$i:$CLASSPATH"
+done
+
+OAP_OPTIONS=" -Doap.logDir=${OAP_LOG_DIR}"
+
+eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH -Dmode=no-init org.apache.skywalking.oap.server.starter.OAPServerStartUp \
+        2>${OAP_LOG_DIR}/oap.log 1> /dev/null &"
+
+if [ $? -eq 0 ]; then
+    sleep 1
+	echo "SkyWalking OAP started successfully!"
+else
+	echo "SkyWalking OAP started failure!"
+	exit 1
+fi

--- a/docs/en/setup/backend/backend-setup.md
+++ b/docs/en/setup/backend/backend-setup.md
@@ -3,7 +3,10 @@ First and most important thing is, SkyWalking backend startup behaviours are dri
 Understood the setting file will help you to read this document.
 
 ## Startup script
-Startup scripts are `/bin/oapService.sh`(.bat)
+The default startup scripts are `/bin/oapService.sh`(.bat). 
+Read [start up mode](backend-start-up-mode.md) document to know other options
+of starting backend.
+
 
 ## application.yml
 The core concept behind this setting file is, SkyWalking collector is based on pure modulization design. 

--- a/docs/en/setup/backend/backend-start-up-mode.md
+++ b/docs/en/setup/backend/backend-start-up-mode.md
@@ -1,0 +1,23 @@
+# Start up mode
+In different deployment tool, such as k8s, you may need different startup mode.
+We provide another two optional startup modes.
+
+## Default mode
+Default mode. Do initialization works if necessary, start listen and provide service. 
+
+Run `/bin/oapService.sh`(.bat) to start in this mode. Also when use `startup.sh`(.bat) to start.
+
+## Init mode
+In this mode, oap server starts up to do initialization works, then exit.
+You could use this mode to init your storage, such as ElasticSearch indexes, MySQL and TiDB tables,
+and init data.
+
+Run `/bin/oapServiceInit.sh`(.bat) to start in this mode.
+
+## No-init mode
+In this mode, oap server starts up without initialization works,
+but it waits for ElasticSearch indexes, MySQL and TiDB tables existed,
+start listen and provide service. Meaning,
+this oap server expect another oap server to do the initialization.
+
+Run `/bin/oapServiceNoInit.sh`(.bat) to start in this mode.

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/RunningMode.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/RunningMode.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.core;
+
+import com.google.common.base.Strings;
+
+/**
+ * The running mode of the OAP server.
+ *
+ * @author wusheng
+ */
+public class RunningMode {
+    private static String MODE = "";
+
+    private RunningMode() {
+    }
+
+    public static void setMode(String mode) {
+        if (Strings.isNullOrEmpty(mode)) {
+            return;
+        }
+        RunningMode.MODE = mode.toLowerCase();
+    }
+
+    /**
+     * Init mode, do all initialization things, and process should exit.
+     * @return true if in this status
+     */
+    public static boolean isInitMode() {
+        return MODE.equals("init");
+    }
+
+    /**
+     * No-init mode, the oap just starts up, but wouldn't do storage init.
+     * @return true if in this status.
+     */
+    public static boolean isNoInitMode() {
+        return MODE.equals("no-init");
+    }
+}

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelInstaller.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelInstaller.java
@@ -18,17 +18,13 @@
 
 package org.apache.skywalking.oap.server.core.storage.model;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.skywalking.oap.server.core.Const;
-import org.apache.skywalking.oap.server.core.CoreModule;
+import java.util.*;
+import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.config.DownsamplingConfigService;
-import org.apache.skywalking.oap.server.core.storage.Downsampling;
-import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.library.client.Client;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
@@ -48,34 +44,46 @@ public abstract class ModelInstaller {
         DownsamplingConfigService downsamplingConfigService = moduleManager.find(CoreModule.NAME).provider().getService(DownsamplingConfigService.class);
 
         List<Model> models = modelGetter.getModels();
-        List<Model> downsamplingModels = new ArrayList<>();
+        List<Model> allModels = new ArrayList<>();
         models.forEach(model -> {
             if (model.isIndicator()) {
                 if (downsamplingConfigService.shouldToHour()) {
-                    downsamplingModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Hour.getName()));
+                    allModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Hour.getName()));
                 }
                 if (downsamplingConfigService.shouldToDay()) {
-                    downsamplingModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Day.getName()));
+                    allModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Day.getName()));
                 }
                 if (downsamplingConfigService.shouldToMonth()) {
-                    downsamplingModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Month.getName()));
+                    allModels.add(model.copy(model.getName() + Const.ID_SPLIT + Downsampling.Month.getName()));
                 }
             }
         });
-        downsamplingModels.addAll(models);
+        allModels.addAll(models);
 
         boolean debug = System.getProperty("debug") != null;
 
-        for (Model model : downsamplingModels) {
-            if (!isExists(client, model)) {
-                logger.info("table: {} does not exist", model.getName());
-                createTable(client, model);
-            } else if (debug) {
-                logger.info("table: {} exists", model.getName());
-                deleteTable(client, model);
-                createTable(client, model);
+        if (RunningMode.isNoInitMode()) {
+            for (Model model : allModels) {
+                while (!isExists(client, model)) {
+                    try {
+                        logger.info("table: {} does not exist. OAP is running in 'no-init' mode, waiting... retry 3s later.", model.getName());
+                        Thread.sleep(3000L);
+                    } catch (InterruptedException e) {
+                    }
+                }
             }
-            columnCheck(client, model);
+        } else {
+            for (Model model : allModels) {
+                if (!isExists(client, model)) {
+                    logger.info("table: {} does not exist", model.getName());
+                    createTable(client, model);
+                } else if (debug) {
+                    logger.info("table: {} exists", model.getName());
+                    deleteTable(client, model);
+                    createTable(client, model);
+                }
+                columnCheck(client, model);
+            }
         }
     }
 

--- a/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerStartUp.java
+++ b/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerStartUp.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.starter;
 
+import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.starter.config.*;
 import org.slf4j.*;
@@ -30,14 +31,16 @@ public class OAPServerStartUp {
     private static final Logger logger = LoggerFactory.getLogger(OAPServerStartUp.class);
 
     public static void main(String[] args) {
+        String mode = System.getProperty("mode");
+        RunningMode.setMode(mode);
+
         ApplicationConfigLoader configLoader = new ApplicationConfigLoader();
         ModuleManager manager = new ModuleManager();
         try {
             ApplicationConfiguration applicationConfiguration = configLoader.load();
             manager.init(applicationConfiguration);
 
-            String mode = System.getProperty("mode");
-            if ("init".equals(mode)) {
+            if (RunningMode.isInitMode()) {
                 logger.info("OAP starts up in init mode successfully, exit now...");
                 System.exit(0);
             }


### PR DESCRIPTION
Provide `init` and `no-init` modes for start up oap backend. cc @peng-yongsheng 