### PR TITLE
fix missing ojdbc component id in component-libraries.yml

### DIFF
--- a/docker/config/component-libraries.yml
+++ b/docker/config/component-libraries.yml
@@ -129,6 +129,9 @@ h2-jdbc-driver:
 mysql-connector-java:
   id: 33
   languages: Java
+ojdbc:
+  id: 34
+  languages: Java  
 Spymemcached:
   id: 35
   languages: Java

--- a/oap-server/server-core/src/test/resources/component-libraries.yml
+++ b/oap-server/server-core/src/test/resources/component-libraries.yml
@@ -129,6 +129,9 @@ h2-jdbc-driver:
 mysql-connector-java:
   id: 33
   languages: Java
+ojdbc:
+  id: 34
+  languages: Java
 Spymemcached:
   id: 35
   languages: Java

--- a/oap-server/server-starter/src/main/resources/component-libraries.yml
+++ b/oap-server/server-starter/src/main/resources/component-libraries.yml
@@ -129,6 +129,9 @@ h2-jdbc-driver:
 mysql-connector-java:
   id: 33
   languages: Java
+ojdbc:
+  id: 34
+  languages: Java
 Spymemcached:
   id: 35
   languages: Java


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
发现oracle 的组件解析出来是ojdbc， id： 34，然后这几个配置的地方没有34这个id。
- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
