### PR TITLE
Set telemetry module and APIs

### DIFF
--- a/apm-dist/release-docs/LICENSE
+++ b/apm-dist/release-docs/LICENSE
@@ -306,6 +306,7 @@ The text of each license is the standard Apache 2.0 license.
     proto files from istio/api: https://github.com/istio/api      Apache 2.0
     consul-client 1.2.6: https://github.com/rickfast/consul-client, Apache 2.0
     okhttp 3.9.0: https://github.com/square/okhttp, Apache 2.0
+    prometheus client_java 0.6.0: https://github.com/prometheus/client_java, Apache 2.0
 
 ========================================================================
 MIT licenses

--- a/docker/config/application.yml
+++ b/docker/config/application.yml
@@ -95,3 +95,5 @@ query:
     path: ${SW_QUERY_GRAPHQL_PATH:/graphql}
 alarm:
   default:
+telemetry:
+  none:

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -40,6 +40,7 @@
         <module>server-testing</module>
         <module>generated-analysis</module>
         <module>generate-tool</module>
+        <module>server-telemetry</module>
     </modules>
 
     <properties>

--- a/oap-server/server-core/pom.xml
+++ b/oap-server/server-core/pom.xml
@@ -34,14 +34,15 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-testing</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.skywalking</groupId>
             <artifactId>library-module</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>telemetry-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -73,6 +74,11 @@
             <groupId>org.apache.skywalking</groupId>
             <artifactId>server-testing</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-testing</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -42,6 +42,7 @@ import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.server.ServerException;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCServer;
 import org.apache.skywalking.oap.server.library.server.jetty.JettyServer;
+import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
 import org.slf4j.*;
 
 /**
@@ -177,6 +178,6 @@ public class CoreModuleProvider extends ModuleProvider {
 
     @Override
     public String[] requiredModules() {
-        return new String[0];
+        return new String[] {TelemetryModule.NAME};
     }
 }

--- a/oap-server/server-starter/src/main/assembly/application.yml
+++ b/oap-server/server-starter/src/main/assembly/application.yml
@@ -95,3 +95,5 @@ query:
     path: ${SW_QUERY_GRAPHQL_PATH:/graphql}
 alarm:
   default:
+telemetry:
+  none:

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -95,3 +95,5 @@ query:
     path: ${SW_QUERY_GRAPHQL_PATH:/graphql}
 alarm:
   default:
+telemetry:
+  none:

--- a/oap-server/server-telemetry/pom.xml
+++ b/oap-server/server-telemetry/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>oap-server</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>6.0.0-GA-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>server-telemetry</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>telemetry-prometheus</module>
+        <module>telemetry-api</module>
+    </modules>
+</project>

--- a/oap-server/server-telemetry/telemetry-api/pom.xml
+++ b/oap-server/server-telemetry/telemetry-api/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>server-telemetry</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>6.0.0-GA-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>telemetry-api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>library-module</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/TelemetryModule.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/TelemetryModule.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry;
+
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.telemetry.api.MetricCreator;
+
+/**
+ * Telemetry module definition
+ *
+ * @author wusheng
+ */
+public class TelemetryModule extends ModuleDefine {
+    public static final String NAME = "telemetry";
+
+    public TelemetryModule() {
+        super(NAME);
+    }
+
+    @Override public Class[] services() {
+        return new Class[] {MetricCreator.class};
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/CounterMetric.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/CounterMetric.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+/**
+ * A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only
+ * increase or be reset to zero on restart. For example, you can use a counter to represent the number of requests
+ * served, tasks completed, or errors.z
+ *
+ * @author wusheng
+ */
+public interface CounterMetric extends TaggableMetric {
+    /**
+     * Increase 1 to counter
+     */
+    void inc();
+
+    /**
+     * Increase the given value to the counter
+     *
+     * @param value
+     */
+    void inc(double value);
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/GaugeMetric.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/GaugeMetric.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+/**
+ * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
+ *
+ * @author wusheng
+ */
+public interface GaugeMetric extends TaggableMetric {
+    /**
+     * Increase 1 to counter
+     */
+    void inc();
+
+    /**
+     * Increase the given value to the counter
+     *
+     * @param value
+     */
+    void inc(double value);
+
+    /**
+     * Decrease 1 to counter
+     */
+    void dec();
+
+    /**
+     * Decrease the given value to the counter
+     *
+     * @param value
+     */
+    void dec(double value);
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/HistogramMetric.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/HistogramMetric.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+import java.io.*;
+
+/**
+ * A histogram samples observations (usually things like request durations or response sizes) and counts them in
+ * configurable buckets. It also provides a sum of all observed values.
+ *
+ * @author wusheng
+ */
+public abstract class HistogramMetric implements TaggableMetric {
+    public Timer createTimer() {
+        return new Timer(this);
+    }
+
+    /**
+     * Observe an execution, get a duration in second.
+     *
+     * @param value duration in second.
+     */
+    public abstract void observe(double value);
+
+    class Timer implements Closeable {
+        private final HistogramMetric metric;
+        private final long startNanos;
+        private double duration;
+
+        public Timer(HistogramMetric metric) {
+            this.metric = metric;
+            startNanos = System.nanoTime();
+        }
+
+        public void finish() {
+            long endNanos = System.nanoTime();
+            duration = (double)(endNanos - startNanos) / 1.0E9D;
+            metric.observe(duration);
+        }
+
+        @Override
+        public void close() throws IOException {
+            finish();
+        }
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricCreator.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricCreator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+import org.apache.skywalking.oap.server.library.module.Service;
+
+/**
+ * Open API to telemetry module, allow to create metric instance with different type. Types inherits from prometheus
+ * project, and plan to move to openmetrics APIs after it is ready.
+ *
+ * @author wusheng
+ */
+public interface MetricCreator extends Service {
+    /**
+     * Create a counter type metric instance.
+     *
+     * @param name
+     * @param tips
+     * @param labels
+     * @return
+     */
+    CounterMetric createCounter(String name, String tips, MetricTag.Keys labels);
+
+    /**
+     * Create a gauge type metric instance.
+     *
+     * @param name
+     * @param tips
+     * @param labels
+     * @return
+     */
+    GaugeMetric createGauge(String name, String tips, MetricTag.Keys labels);
+
+    /**
+     * Create a Histogram type metric instance.
+     *
+     * @param name
+     * @param tips
+     * @param labels
+     * @param buckets Time bucket for duration.
+     * @return
+     */
+    HistogramMetric createHistogramMetric(String name, String tips, MetricTag.Keys labels, double... buckets);
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricTag.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/MetricTag.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+/**
+ * Tag for the target metric.
+ *
+ * The tag values should be set in putting value phase.
+ */
+public class MetricTag {
+    public class Keys {
+        private String[] keys;
+
+        public Keys() {
+            this.keys = new String[0];
+        }
+
+        public Keys(String... keys) {
+            this.keys = keys;
+        }
+
+        public String[] getKeys() {
+            return keys;
+        }
+    }
+
+    public class Values {
+        private String[] values;
+
+        public Values(Keys keys) {
+            this.values = new String[0];
+        }
+
+        public Values(String... keys) {
+            this.values = keys;
+        }
+
+        public String[] getValues() {
+            return values;
+        }
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/TaggableMetric.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/TaggableMetric.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+/**
+ * Set tag values to this metric instance.
+ *
+ * @author wusheng
+ */
+public interface TaggableMetric {
+    void setTagValues(MetricTag.Values values);
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/TelemetryRelatedContext.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/api/TelemetryRelatedContext.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.api;
+
+/**
+ * The telemetry context which the metric instances may need to know.
+ * @author wusheng
+ */
+public enum TelemetryRelatedContext {
+    INTANCE;
+
+    private volatile String id = "default";
+    private TelemetryRelatedContext(){}
+
+    /**
+     * Set a global ID to represent the current oap instance
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get the oap instance ID, if be set before, otherwise, return `default` string.
+     *
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/none/MetricCreatorNoop.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/none/MetricCreatorNoop.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.none;
+
+import org.apache.skywalking.oap.server.telemetry.api.*;
+
+/**
+ * A no-op metric create, just create nut shell metric instance.
+ *
+ * @author wusheng
+ */
+public class MetricCreatorNoop implements MetricCreator {
+    @Override public CounterMetric createCounter(String name, String tips, MetricTag.Keys labels) {
+        return null;
+    }
+
+    @Override public GaugeMetric createGauge(String name, String tips, MetricTag.Keys labels) {
+        return null;
+    }
+
+    @Override
+    public HistogramMetric createHistogramMetric(String name, String tips, MetricTag.Keys labels, double... buckets) {
+        return null;
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/none/NoneTelemetryProvider.java
+++ b/oap-server/server-telemetry/telemetry-api/src/main/java/org/apache/skywalking/oap/server/telemetry/none/NoneTelemetryProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.telemetry.none;
+
+import org.apache.skywalking.oap.server.library.module.*;
+import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
+import org.apache.skywalking.oap.server.telemetry.api.MetricCreator;
+
+/**
+ * A nutshell telemetry implementor.
+ *
+ * @author wusheng
+ */
+public class NoneTelemetryProvider extends ModuleProvider {
+    @Override public String name() {
+        return "none";
+    }
+
+    @Override public Class<? extends ModuleDefine> module() {
+        return TelemetryModule.class;
+    }
+
+    @Override public ModuleConfig createConfigBeanIfAbsent() {
+        return new ModuleConfig() {
+        };
+    }
+
+    @Override public void prepare() throws ServiceNotProvidedException, ModuleStartException {
+        this.registerServiceImplementation(MetricCreator.class, new MetricCreatorNoop());
+    }
+
+    @Override public void start() throws ServiceNotProvidedException, ModuleStartException {
+
+    }
+
+    @Override public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
+
+    }
+
+    @Override public String[] requiredModules() {
+        return new String[0];
+    }
+}

--- a/oap-server/server-telemetry/telemetry-api/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleDefine
+++ b/oap-server/server-telemetry/telemetry-api/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleDefine
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.skywalking.oap.server.telemetry.TelemetryModule

--- a/oap-server/server-telemetry/telemetry-api/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/oap-server/server-telemetry/telemetry-api/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.skywalking.oap.server.telemetry.none.NoneTelemetryProvider

--- a/oap-server/server-telemetry/telemetry-prometheus/pom.xml
+++ b/oap-server/server-telemetry/telemetry-prometheus/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>server-telemetry</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>6.0.0-GA-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>telemetry-prometheus</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- The client -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <!-- Hotspot JVM metrics-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <!-- Exposition HTTPServer-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
I set the following APIs for backend telemetry, including metric types
1. Counter
1. Gauge
1. Histogram

```java
/**
 * Open API to telemetry module, allow to create metric instance with different type. Types inherits from prometheus
 * project, and plan to move to openmetrics APIs after it is ready.
 *
 * @author wusheng
 */
public interface MetricCreator extends Service {
    /**
     * Create a counter type metric instance.
     *
     * @param name
     * @param tips
     * @param labels
     * @return
     */
    CounterMetric createCounter(String name, String tips, MetricTag.Keys labels);

    /**
     * Create a gauge type metric instance.
     *
     * @param name
     * @param tips
     * @param labels
     * @return
     */
    GaugeMetric createGauge(String name, String tips, MetricTag.Keys labels);

    /**
     * Create a Histogram type metric instance.
     *
     * @param name
     * @param tips
     * @param labels
     * @param buckets Time bucket for duration.
     * @return
     */
    HistogramMetric createHistogramMetric(String name, String tips, MetricTag.Keys labels, double... buckets);
}
```

All these concepts are from Prometheus core concepts. 

cc @apache/skywalking-committers 