### PR TITLE
Just register entry and exit span op names.

### DIFF
--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/decorator/SpanDecorator.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/decorator/SpanDecorator.java
@@ -92,14 +92,6 @@ public class SpanDecorator implements StandardBuilder {
         }
     }
 
-    public int getSpanTypeValue() {
-        if (isOrigin) {
-            return isV2 ? spanObjectV2.getSpanTypeValue() : spanObject.getSpanTypeValue();
-        } else {
-            return isV2 ? spanBuilderV2.getSpanTypeValue() : spanBuilder.getSpanTypeValue();
-        }
-    }
-
     public SpanLayer getSpanLayer() {
         if (isOrigin) {
             return isV2 ? spanObjectV2.getSpanLayer() : spanObject.getSpanLayer();

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/listener/segment/SegmentSpanListener.java
@@ -21,20 +21,12 @@ package org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener
 import org.apache.skywalking.apm.network.language.agent.UniqueId;
 import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.cache.EndpointInventoryCache;
-import org.apache.skywalking.oap.server.core.source.Segment;
-import org.apache.skywalking.oap.server.core.source.SourceReceiver;
+import org.apache.skywalking.oap.server.core.source.*;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
-import org.apache.skywalking.oap.server.library.util.BooleanUtils;
-import org.apache.skywalking.oap.server.library.util.TimeBucketUtils;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.decorator.SegmentCoreInfo;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.decorator.SpanDecorator;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.EntrySpanListener;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.FirstSpanListener;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.GlobalTraceIdsListener;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.SpanListener;
-import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.SpanListenerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.skywalking.oap.server.library.util.*;
+import org.apache.skywalking.oap.server.receiver.trace.provider.parser.decorator.*;
+import org.apache.skywalking.oap.server.receiver.trace.provider.parser.listener.*;
+import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
@@ -49,7 +41,7 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
     private final EndpointInventoryCache serviceNameCacheService;
     private SAMPLE_STATUS sampleStatus = SAMPLE_STATUS.UNKNOWN;
     private int entryEndpointId = 0;
-    private int firstEndpointId = 0;
+    private String firstSpanOperationName = "";
 
     private SegmentSpanListener(ModuleManager moduleManager, TraceSegmentSampler sampler) {
         this.sampler = sampler;
@@ -82,7 +74,7 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
          */
         segment.setVersion(segmentCoreInfo.isV2() ? 2 : 1);
 
-        firstEndpointId = spanDecorator.getOperationNameId();
+        firstSpanOperationName = spanDecorator.getOperationName();
     }
 
     @Override public void parseEntry(SpanDecorator spanDecorator, SegmentCoreInfo segmentCoreInfo) {
@@ -123,8 +115,7 @@ public class SegmentSpanListener implements FirstSpanListener, EntrySpanListener
         }
 
         if (entryEndpointId == 0) {
-            segment.setEndpointId(firstEndpointId);
-            segment.setEndpointName(serviceNameCacheService.get(firstEndpointId).getName());
+            segment.setEndpointName(firstSpanOperationName);
         } else {
             segment.setEndpointId(entryEndpointId);
             segment.setEndpointName(serviceNameCacheService.get(entryEndpointId).getName());

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/SpanIdExchanger.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.oap.server.receiver.trace.provider.parser.standardization;
 
 import com.google.common.base.Strings;
+import org.apache.skywalking.apm.network.language.agent.SpanType;
 import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.config.IComponentLibraryCatalogService;
 import org.apache.skywalking.oap.server.core.register.NodeType;
@@ -87,7 +88,7 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
             }
         }
 
-        if (standardBuilder.getOperationNameId() == 0) {
+        if (standardBuilder.getOperationNameId() == 0 && needExchangeOperationName(standardBuilder)) {
             String endpointName = Strings.isNullOrEmpty(standardBuilder.getOperationName()) ? Const.DOMAIN_OPERATION_NAME : standardBuilder.getOperationName();
             int endpointId = endpointInventoryRegister.getOrCreate(serviceId, endpointName, DetectPoint.fromSpanType(standardBuilder.getSpanType()));
 
@@ -103,5 +104,10 @@ public class SpanIdExchanger implements IdExchanger<SpanDecorator> {
             }
         }
         return true;
+    }
+
+    private boolean needExchangeOperationName(SpanDecorator standardBuilder) {
+        return SpanType.Entry.equals(standardBuilder.getSpanType())
+            || SpanType.Exit.equals(standardBuilder.getSpanType());
     }
 }


### PR DESCRIPTION
Since people begin to contribute serialization plugin for skywalking, I expect to see more and more local span related plugin coming. For avoiding performance influence to backend, I am trying to remove local span op name register from segment parse.

1. `SpanIdExchanger#exchange` only register `entry` and `exit` spans op name.
1. `SegmentSpanListener` use first span op name, if can't find entry span op id in this segment.

For agent side, `EndpointNameDictionary#findOrPrepare4Register` and `EndpointNameDictionary#findOnly` are both working for entry and exit span only already. This has been changed in beta release.