### PR TITLE
Support service inventory extension fields in json format

### DIFF
--- a/docs/en/guides/README.md
+++ b/docs/en/guides/README.md
@@ -37,6 +37,8 @@ and private plugin developer should read this.
 - [Storage extension development guide](storage-extention.md). Help potential contributors to build a new 
 storage implementor besides the official.
 - [Customize analysis by oal script](write-oal.md). Guide you to use oal script to make your own metric available.
+- [Backend Inventory entity extension](inventory-extension.md). If you want to extend SkyWalking inventory entities, and
+want to push upstream back to our Apache OSS repo, please read these principles.
 
 ### UI developer
 Our UI is constituted by static pages and web container.

--- a/docs/en/guides/inventory-extension.md
+++ b/docs/en/guides/inventory-extension.md
@@ -1,0 +1,31 @@
+# Backend Inventory Entity Extension
+SkyWalking includes four inventory entities.
+- Service Inventory
+- Service Instance Inventory
+- Endpoint Inventory
+- Network Address Inventory
+
+All metric, topology, trace and alarm are related to these entity IDs. 
+
+For understanding the **Service**, **Service Instance** and **Endpoint** concepts,
+please read [Project Overview](../concepts-and-designs/overview.md#why-use-skywalking).
+
+For **Network Address Inventory**, it represents all network address, in IP:port, hostname, domain name
+formats, which are detected by language agents or other probes.
+
+## Extension
+Right now, only **Service Inventory** extension is already supported in backend core.
+Service provides field `properties` in Json format, which is usually used for specific service 
+rather than normal business services, such as Database, Cache, MQ, etc.
+
+For keeping code consistent and friendly in query and visualization, the Json properties
+need to follow the rules.
+
+### Database
+1. NodeType == **Database(1)**
+1. Json properties include following keys.
+  - `database`. Database name, such as MySQL, PostgreSQL
+  - `db.type`. Database type, such as sql db, redis db.
+  - `db.instance`. Database instance name.
+
+

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/NetworkAddressInventory.java
@@ -82,6 +82,17 @@ public class NetworkAddressInventory extends RegisterSource {
         return true;
     }
 
+    public NetworkAddressInventory getClone() {
+        NetworkAddressInventory inventory = new NetworkAddressInventory();
+        inventory.setSequence(getSequence());
+        inventory.setRegisterTime(getRegisterTime());
+        inventory.setHeartbeatTime(getHeartbeatTime());
+        inventory.setName(name);
+        inventory.setNodeType(nodeType);
+
+        return inventory;
+    }
+
     @Override public void combine(RegisterSource registerSource) {
         super.combine(registerSource);
         NetworkAddressInventory inventory = (NetworkAddressInventory)registerSource;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.register;
 
+import com.google.gson.*;
 import java.util.*;
 import lombok.*;
 import org.apache.skywalking.oap.server.core.Const;
@@ -46,6 +47,7 @@ public class ServiceInventory extends RegisterSource {
     public static final String NODE_TYPE = "node_type";
     public static final String MAPPING_SERVICE_ID = "mapping_service_id";
     public static final String MAPPING_LAST_UPDATE_TIME = "mapping_last_update_time";
+    public static final String PROPERTIES = "properties";
 
     @Setter @Getter @Column(columnName = NAME, matchQuery = true) private String name = Const.EMPTY_STRING;
     @Setter @Getter @Column(columnName = IS_ADDRESS) private int isAddress;
@@ -53,6 +55,8 @@ public class ServiceInventory extends RegisterSource {
     @Setter(AccessLevel.PRIVATE) @Getter(AccessLevel.PRIVATE) @Column(columnName = NODE_TYPE) private int nodeType;
     @Setter @Getter @Column(columnName = MAPPING_SERVICE_ID) private int mappingServiceId;
     @Setter @Getter @Column(columnName = MAPPING_LAST_UPDATE_TIME) private long mappingLastUpdateTime;
+    @Getter(AccessLevel.PRIVATE) @Column(columnName = MAPPING_LAST_UPDATE_TIME) private String prop;
+    @Getter private JsonObject properties;
 
     public NodeType getServiceNodeType() {
         return NodeType.get(this.nodeType);
@@ -86,6 +90,24 @@ public class ServiceInventory extends RegisterSource {
         return result;
     }
 
+    public void setProperties(JsonObject properties) {
+        this.properties = properties;
+        if (properties != null && properties.keySet().size() > 0) {
+            this.prop = properties.toString();
+        }
+    }
+
+    private void setProp(String prop) {
+        this.prop = prop;
+        if (!Strings.isNullOrEmpty(prop)) {
+            this.properties = new Gson().fromJson(prop, JsonObject.class);
+        }
+    }
+
+    public boolean hasProperties() {
+        return prop != null && prop.length() > 0;
+    }
+
     public ServiceInventory getClone() {
         ServiceInventory inventory = new ServiceInventory();
         inventory.setSequence(getSequence());
@@ -97,6 +119,7 @@ public class ServiceInventory extends RegisterSource {
         inventory.setAddressId(addressId);
         inventory.setMappingLastUpdateTime(mappingLastUpdateTime);
         inventory.setMappingServiceId(mappingServiceId);
+        inventory.setProp(prop);
 
         return inventory;
     }
@@ -133,6 +156,7 @@ public class ServiceInventory extends RegisterSource {
         remoteBuilder.addDataLongs(getMappingLastUpdateTime());
 
         remoteBuilder.addDataStrings(Strings.isNullOrEmpty(name) ? Const.EMPTY_STRING : name);
+        remoteBuilder.addDataStrings(Strings.isNullOrEmpty(prop) ? Const.EMPTY_STRING : prop);
         return remoteBuilder;
     }
 
@@ -148,6 +172,8 @@ public class ServiceInventory extends RegisterSource {
         setMappingLastUpdateTime(remoteData.getDataLongs(2));
 
         setName(remoteData.getDataStrings(0));
+        setProp(remoteData.getDataStrings(1));
+
     }
 
     @Override public int remoteHashCode() {
@@ -158,6 +184,7 @@ public class ServiceInventory extends RegisterSource {
         super.combine(registerSource);
         ServiceInventory serviceInventory = (ServiceInventory)registerSource;
         nodeType = serviceInventory.nodeType;
+        setProp(serviceInventory.getProp());
         if (Const.NONE != serviceInventory.getMappingServiceId() && serviceInventory.getMappingLastUpdateTime() >= this.getMappingLastUpdateTime()) {
             this.mappingServiceId = serviceInventory.getMappingServiceId();
             this.mappingLastUpdateTime = serviceInventory.getMappingLastUpdateTime();
@@ -177,6 +204,7 @@ public class ServiceInventory extends RegisterSource {
             inventory.setRegisterTime((Long)dbMap.get(REGISTER_TIME));
             inventory.setHeartbeatTime((Long)dbMap.get(HEARTBEAT_TIME));
             inventory.setMappingLastUpdateTime((Long)dbMap.get(MAPPING_LAST_UPDATE_TIME));
+            inventory.setProp((String)dbMap.get(PROPERTIES));
             return inventory;
         }
 
@@ -191,6 +219,7 @@ public class ServiceInventory extends RegisterSource {
             map.put(REGISTER_TIME, storageData.getRegisterTime());
             map.put(HEARTBEAT_TIME, storageData.getHeartbeatTime());
             map.put(MAPPING_LAST_UPDATE_TIME, storageData.getMappingLastUpdateTime());
+            map.put(PROPERTIES, storageData.getProp());
             return map;
         }
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/ServiceInventory.java
@@ -55,7 +55,7 @@ public class ServiceInventory extends RegisterSource {
     @Setter(AccessLevel.PRIVATE) @Getter(AccessLevel.PRIVATE) @Column(columnName = NODE_TYPE) private int nodeType;
     @Setter @Getter @Column(columnName = MAPPING_SERVICE_ID) private int mappingServiceId;
     @Setter @Getter @Column(columnName = MAPPING_LAST_UPDATE_TIME) private long mappingLastUpdateTime;
-    @Getter(AccessLevel.PRIVATE) @Column(columnName = MAPPING_LAST_UPDATE_TIME) private String prop;
+    @Getter(AccessLevel.PRIVATE) @Column(columnName = PROPERTIES) private String prop;
     @Getter private JsonObject properties;
 
     public NodeType getServiceNodeType() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/INetworkAddressInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/INetworkAddressInventoryRegister.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.register.service;
 
+import com.google.gson.JsonObject;
 import org.apache.skywalking.oap.server.core.register.NodeType;
 import org.apache.skywalking.oap.server.library.module.Service;
 
@@ -25,7 +26,7 @@ import org.apache.skywalking.oap.server.library.module.Service;
  * @author peng-yongsheng
  */
 public interface INetworkAddressInventoryRegister extends Service {
-    int getOrCreate(String networkAddress);
+    int getOrCreate(String networkAddress, JsonObject properties);
 
     int get(String networkAddress);
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IServiceInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/IServiceInventoryRegister.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.core.register.service;
 
+import com.google.gson.JsonObject;
 import org.apache.skywalking.oap.server.library.module.Service;
 
 /**
@@ -25,9 +26,11 @@ import org.apache.skywalking.oap.server.library.module.Service;
  */
 public interface IServiceInventoryRegister extends Service {
 
-    int getOrCreate(String serviceName);
+    int getOrCreate(String serviceName, JsonObject properties);
 
-    int getOrCreate(int addressId, String serviceName);
+    int getOrCreate(int addressId, String serviceName, JsonObject properties);
+
+    void updateProperties(int serviceId, JsonObject properties);
 
     void heartbeat(int serviceId, long heartBeatTime);
 

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInventoryRegister.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/register/service/ServiceInventoryRegister.java
@@ -18,10 +18,11 @@
 
 package org.apache.skywalking.oap.server.core.register.service;
 
+import com.google.gson.JsonObject;
 import java.util.Objects;
 import org.apache.skywalking.oap.server.core.*;
 import org.apache.skywalking.oap.server.core.cache.ServiceInventoryCache;
-import org.apache.skywalking.oap.server.core.register.ServiceInventory;
+import org.apache.skywalking.oap.server.core.register.*;
 import org.apache.skywalking.oap.server.core.register.worker.InventoryProcess;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.util.BooleanUtils;
@@ -50,7 +51,7 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
         return serviceInventoryCache;
     }
 
-    @Override public int getOrCreate(String serviceName) {
+    @Override public int getOrCreate(String serviceName, JsonObject properties) {
         int serviceId = getServiceInventoryCache().getServiceId(serviceName);
 
         if (serviceId == Const.NONE) {
@@ -64,13 +65,14 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
             serviceInventory.setHeartbeatTime(now);
             serviceInventory.setMappingServiceId(Const.NONE);
             serviceInventory.setMappingLastUpdateTime(now);
+            serviceInventory.setProperties(properties);
 
             InventoryProcess.INSTANCE.in(serviceInventory);
         }
         return serviceId;
     }
 
-    @Override public int getOrCreate(int addressId, String serviceName) {
+    @Override public int getOrCreate(int addressId, String serviceName, JsonObject properties) {
         int serviceId = getServiceInventoryCache().getServiceId(addressId);
 
         if (serviceId == Const.NONE) {
@@ -89,9 +91,23 @@ public class ServiceInventoryRegister implements IServiceInventoryRegister {
         return serviceId;
     }
 
+    @Override public void updateProperties(int serviceId, JsonObject properties) {
+        ServiceInventory serviceInventory = getServiceInventoryCache().get(serviceId);
+        if (Objects.nonNull(serviceInventory)) {
+            serviceInventory = serviceInventory.getClone();
+            serviceInventory.setProperties(properties);
+            serviceInventory.setMappingLastUpdateTime(System.currentTimeMillis());
+
+            InventoryProcess.INSTANCE.in(serviceInventory);
+        } else {
+            logger.warn("Service {} properties update, but not found in storage.");
+        }
+    }
+
     @Override public void heartbeat(int serviceId, long heartBeatTime) {
         ServiceInventory serviceInventory = getServiceInventoryCache().get(serviceId);
         if (Objects.nonNull(serviceInventory)) {
+            serviceInventory = serviceInventory.getClone();
             serviceInventory.setHeartbeatTime(heartBeatTime);
 
             InventoryProcess.INSTANCE.in(serviceInventory);

--- a/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
+++ b/oap-server/server-receiver-plugin/skywalking-mesh-receiver-plugin/src/main/java/org/apache/skywalking/aop/server/receiver/mesh/ServiceMeshMetricDataDecorator.java
@@ -44,7 +44,7 @@ public class ServiceMeshMetricDataDecorator {
         boolean isRegistered = true;
         sourceServiceId = origin.getSourceServiceId();
         if (sourceServiceId == Const.NONE) {
-            sourceServiceId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(origin.getSourceServiceName());
+            sourceServiceId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(origin.getSourceServiceName(), null);
             if (sourceServiceId != Const.NONE) {
                 getNewDataBuilder().setSourceServiceId(sourceServiceId);
             } else {
@@ -65,7 +65,7 @@ public class ServiceMeshMetricDataDecorator {
         }
         destServiceId = origin.getDestServiceId();
         if (destServiceId == Const.NONE) {
-            destServiceId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(origin.getDestServiceName());
+            destServiceId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(origin.getDestServiceName(), null);
             if (destServiceId != Const.NONE) {
                 getNewDataBuilder().setDestServiceId(destServiceId);
             } else {

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/grpc/ApplicationRegisterHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/grpc/ApplicationRegisterHandler.java
@@ -47,7 +47,7 @@ public class ApplicationRegisterHandler extends ApplicationRegisterServiceGrpc.A
 
         ApplicationMapping.Builder builder = ApplicationMapping.newBuilder();
         String serviceName = request.getApplicationCode();
-        int serviceId = serviceInventoryRegister.getOrCreate(serviceName);
+        int serviceId = serviceInventoryRegister.getOrCreate(serviceName, null);
 
         if (serviceId != Const.NONE) {
             KeyWithIntegerValue value = KeyWithIntegerValue.newBuilder().setKey(serviceName).setValue(serviceId).build();

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/grpc/NetworkAddressRegisterServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/grpc/NetworkAddressRegisterServiceHandler.java
@@ -50,7 +50,7 @@ public class NetworkAddressRegisterServiceHandler extends NetworkAddressRegister
 
         NetworkAddressMappings.Builder builder = NetworkAddressMappings.newBuilder();
         for (String networkAddress : addressesList) {
-            int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress);
+            int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress, null);
 
             if (addressId != Const.NONE) {
                 KeyWithIntegerValue value = KeyWithIntegerValue.newBuilder().setKey(networkAddress).setValue(addressId).build();

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/rest/ApplicationRegisterServletHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/rest/ApplicationRegisterServletHandler.java
@@ -57,7 +57,7 @@ public class ApplicationRegisterServletHandler extends JettyJsonHandler {
             JsonArray applicationCodes = gson.fromJson(req.getReader(), JsonArray.class);
             for (int i = 0; i < applicationCodes.size(); i++) {
                 String applicationCode = applicationCodes.get(i).getAsString();
-                int applicationId = serviceInventoryRegister.getOrCreate(applicationCode);
+                int applicationId = serviceInventoryRegister.getOrCreate(applicationCode, null);
                 JsonObject mapping = new JsonObject();
                 mapping.addProperty(APPLICATION_CODE, applicationCode);
                 mapping.addProperty(APPLICATION_ID, applicationId);

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/rest/NetworkAddressRegisterServletHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v5/rest/NetworkAddressRegisterServletHandler.java
@@ -62,7 +62,7 @@ public class NetworkAddressRegisterServletHandler extends JettyJsonHandler {
                     logger.debug("network getAddress register, network getAddress: {}", networkAddress);
                 }
 
-                int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress);
+                int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress, null);
                 JsonObject mapping = new JsonObject();
                 mapping.addProperty(ADDRESS_ID, addressId);
                 mapping.addProperty(NETWORK_ADDRESS, networkAddress);

--- a/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v6/grpc/RegisterServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-register-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/register/provider/handler/v6/grpc/RegisterServiceHandler.java
@@ -63,7 +63,7 @@ public class RegisterServiceHandler extends RegisterGrpc.RegisterImplBase implem
             if (logger.isDebugEnabled()) {
                 logger.debug("Register service, service code: {}", serviceName);
             }
-            int serviceId = serviceInventoryRegister.getOrCreate(serviceName);
+            int serviceId = serviceInventoryRegister.getOrCreate(serviceName, null);
 
             if (serviceId != Const.NONE) {
                 KeyIntValuePair value = KeyIntValuePair.newBuilder().setKey(serviceName).setValue(serviceId).build();
@@ -149,7 +149,7 @@ public class RegisterServiceHandler extends RegisterGrpc.RegisterImplBase implem
         NetAddressMapping.Builder builder = NetAddressMapping.newBuilder();
 
         request.getAddressesList().forEach(networkAddress -> {
-            int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress);
+            int addressId = networkAddressInventoryRegister.getOrCreate(networkAddress, null);
 
             if (addressId != Const.NONE) {
                 builder.addAddressIds(KeyIntValuePair.newBuilder().setKey(networkAddress).setValue(addressId));
@@ -186,7 +186,7 @@ public class RegisterServiceHandler extends RegisterGrpc.RegisterImplBase implem
                     return;
                 }
 
-                networkAddressId = networkAddressInventoryRegister.getOrCreate(address);
+                networkAddressId = networkAddressInventoryRegister.getOrCreate(address, null);
                 if (networkAddressId == Const.NONE) {
                     return;
                 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/decorator/SpanDecorator.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/decorator/SpanDecorator.java
@@ -18,9 +18,9 @@
 
 package org.apache.skywalking.oap.server.receiver.trace.provider.parser.decorator;
 
-import org.apache.skywalking.apm.network.language.agent.SpanLayer;
-import org.apache.skywalking.apm.network.language.agent.SpanObject;
-import org.apache.skywalking.apm.network.language.agent.SpanType;
+import java.util.*;
+import org.apache.skywalking.apm.network.common.KeyStringValuePair;
+import org.apache.skywalking.apm.network.language.agent.*;
 import org.apache.skywalking.apm.network.language.agent.v2.SpanObjectV2;
 
 import static java.util.Objects.isNull;
@@ -281,6 +281,14 @@ public class SpanDecorator implements StandardBuilder {
         return referenceDecorators[index];
     }
 
+    public List<KeyStringValuePair> getAllTags() {
+        if (isOrigin) {
+            return isV2 ? spanObjectV2.getTagsList() : convert(spanObject.getTagsList());
+        } else {
+            return isV2 ? spanBuilderV2.getTagsList() : convert(spanBuilder.getTagsList());
+        }
+    }
+
     @Override public void toBuilder() {
         if (this.isOrigin) {
             this.isOrigin = false;
@@ -291,5 +299,17 @@ public class SpanDecorator implements StandardBuilder {
             }
             standardBuilder.toBuilder();
         }
+    }
+
+    private List<KeyStringValuePair> convert(List<KeyWithStringValue> list) {
+        List<KeyStringValuePair> result = new ArrayList<>();
+        if (list != null) {
+            list.forEach(element -> {
+                result.add(KeyStringValuePair.newBuilder()
+                    .setKey(element.getKey())
+                    .setValue(element.getValue()).build());
+            });
+        }
+        return result;
     }
 }

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/parser/standardization/ReferenceIdExchanger.java
@@ -88,7 +88,7 @@ public class ReferenceIdExchanger implements IdExchanger<ReferenceDecorator> {
         }
 
         if (standardBuilder.getNetworkAddressId() == 0 && !Strings.isNullOrEmpty(standardBuilder.getNetworkAddress())) {
-            int networkAddressId = networkAddressInventoryRegister.getOrCreate(standardBuilder.getNetworkAddress());
+            int networkAddressId = networkAddressInventoryRegister.getOrCreate(standardBuilder.getNetworkAddress(), null);
 
             if (networkAddressId == 0) {
                 if (logger.isDebugEnabled()) {

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/handler/SpanProcessor.java
@@ -48,7 +48,7 @@ public class SpanProcessor {
             // In Zipkin, the local service name represents the application owner.
             String applicationCode = span.localServiceName();
             if (applicationCode != null) {
-                int applicationId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(applicationCode);
+                int applicationId = CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(applicationCode, null);
                 if (applicationId != 0) {
                     CoreRegisterLinker.getServiceInstanceInventoryRegister().getOrCreate(applicationId, applicationCode, applicationCode,
                         span.timestampAsLong(),

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/transform/SegmentBuilder.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/zipkin/transform/SegmentBuilder.java
@@ -301,7 +301,7 @@ public class SegmentBuilder {
 
         private Segment addApp(String serviceCode, long registerTime) throws Exception {
             int serviceId = waitForExchange(() ->
-                    CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(serviceCode),
+                    CoreRegisterLinker.getServiceInventoryRegister().getOrCreate(serviceCode, null),
                 10
             );
 

--- a/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/zipkin/transform/SpringSleuthSegmentBuilderTest.java
+++ b/oap-server/server-receiver-plugin/zipkin-receiver-plugin/src/test/java/org/apache/skywalking/oap/server/receiver/zipkin/transform/SpringSleuthSegmentBuilderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.receiver.zipkin.transform;
 
+import com.google.gson.JsonObject;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -27,7 +28,7 @@ import org.apache.skywalking.apm.network.language.agent.SpanType;
 import org.apache.skywalking.apm.network.language.agent.v2.SegmentObject;
 import org.apache.skywalking.apm.network.language.agent.v2.SegmentReference;
 import org.apache.skywalking.apm.network.language.agent.v2.SpanObjectV2;
-import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
+import org.apache.skywalking.oap.server.core.register.*;
 import org.apache.skywalking.oap.server.core.register.service.IServiceInstanceInventoryRegister;
 import org.apache.skywalking.oap.server.core.register.service.IServiceInventoryRegister;
 import org.apache.skywalking.oap.server.receiver.zipkin.CoreRegisterLinker;
@@ -52,7 +53,7 @@ public class SpringSleuthSegmentBuilderTest implements SegmentListener {
     public void testTransform() throws Exception {
 
         IServiceInventoryRegister applicationIDService = new IServiceInventoryRegister() {
-            @Override public int getOrCreate(String serviceName) {
+            @Override public int getOrCreate(String serviceName, JsonObject properties) {
                 String key = "AppCode:" + serviceName;
                 if (applicationRegister.containsKey(key)) {
                     return applicationRegister.get(key);
@@ -63,7 +64,7 @@ public class SpringSleuthSegmentBuilderTest implements SegmentListener {
                 }
             }
 
-            @Override public int getOrCreate(int addressId, String serviceName) {
+            @Override public int getOrCreate(int addressId, String serviceName, JsonObject properties) {
                 String key = "Address:" + serviceName;
                 if (applicationRegister.containsKey(key)) {
                     return applicationRegister.get(key);
@@ -72,6 +73,9 @@ public class SpringSleuthSegmentBuilderTest implements SegmentListener {
                     applicationRegister.put(key, id);
                     return id;
                 }
+            }
+
+            @Override public void updateProperties(int serviceId, JsonObject properties) {
             }
 
             @Override public void heartbeat(int serviceId, long heartBeatTime) {


### PR DESCRIPTION
For service inventory extension, I add an extension point in service inventory entity. It is in JSON format, but it could only be set once right now for performance consideration.

Also, I provide the default database service properties initialization codes. @liuhaoyang which you may want to extend. I just put the basic fields, which I think make sense.

And all contributions around inventory extension should following the consistent rules. So I also provide a document in development guide.