### PR TITLE
Optimize the agent grpc channel management.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/conf/Config.java
@@ -88,7 +88,7 @@ public class Config {
          */
         public static long GRPC_CHANNEL_CHECK_INTERVAL = 30;
         /**
-         * application and service registry check interval
+         * service and endpoint registry check interval
          */
         public static long APP_AND_SERVICE_REGISTER_CHECK_INTERVAL = 3;
         /**

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -103,6 +103,8 @@ public class GRPCChannelManager implements BootService, Runnable {
                             .addManagedChannelBuilder(new TLSChannelBuilder())
                             .addChannelDecorator(new AuthenticationDecorator())
                             .build();
+
+                        notify(GRPCChannelStatus.CONNECTED);
                     }
 
                     reconnect = false;

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -94,7 +94,7 @@ public class GRPCChannelManager implements BootService, Runnable {
                         server = grpcServers.get(index);
                         String[] ipAndPort = server.split(":");
 
-                        if(managedChannel != null){
+                        if (managedChannel != null) {
                             managedChannel.shutdownNow();
                         }
 
@@ -111,7 +111,6 @@ public class GRPCChannelManager implements BootService, Runnable {
                     return;
                 } catch (Throwable t) {
                     logger.error(t, "Create channel to {} fail.", server);
-                    notify(GRPCChannelStatus.DISCONNECT);
                 }
             }
 

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManagerTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManagerTest.java
@@ -42,7 +42,6 @@ public class GRPCChannelManagerTest {
         GRPCChannelManager manager = new GRPCChannelManager();
         manager.addChannelListener(new GRPCChannelListener() {
             @Override public void statusChanged(GRPCChannelStatus status) {
-                System.out.println(status);
             }
         });
 

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManagerTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.remote;
+
+import io.grpc.Server;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.net.InetSocketAddress;
+import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.network.register.v2.*;
+import org.junit.*;
+
+public class GRPCChannelManagerTest {
+    @BeforeClass
+    public static void setup() {
+        Config.Collector.BACKEND_SERVICE = "127.0.0.1:8080";
+    }
+
+    @AfterClass
+    public static void clear() {
+        Config.Collector.BACKEND_SERVICE = "";
+    }
+
+    //@Test
+    public void testConnected() throws Throwable {
+        GRPCChannelManager manager = new GRPCChannelManager();
+        manager.addChannelListener(new GRPCChannelListener() {
+            @Override public void statusChanged(GRPCChannelStatus status) {
+                System.out.println(status);
+            }
+        });
+
+        manager.boot();
+        Thread.sleep(1000);
+
+        RegisterGrpc.RegisterBlockingStub stub = RegisterGrpc.newBlockingStub(manager.getChannel());
+        try {
+            stub.doServiceRegister(Services.newBuilder().addServices(Service.newBuilder().setServiceName("abc")).build());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forAddress(new InetSocketAddress("127.0.0.1", 8080));
+        nettyServerBuilder.addService(new RegisterGrpc.RegisterImplBase() {
+            @Override
+            public void doServiceRegister(Services request, StreamObserver<ServiceRegisterMapping> responseObserver) {
+            }
+        });
+        Server server = nettyServerBuilder.build();
+        server.start();
+        Thread.sleep(1000);
+
+        boolean registerSuccess = false;
+        try {
+            stub.doServiceRegister(Services.newBuilder().addServices(Service.newBuilder().setServiceName("abc")).build());
+            registerSuccess = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        Assert.assertTrue(registerSuccess);
+        server.shutdownNow();
+    }
+}


### PR DESCRIPTION
From the #2190 , when re-select and reconnect happens, there is possible to leak memory and grpc client stub. In this pull request, I am making this adjustment.
1. Only reconnect when re-select got another network address. 
1. We still suggest to use load balance between agent and collector cluster, also because of this and (1), reconnect wouldn't be controlled by agent client even. gRPC client supports reconnect to the same target address already. See the `GRPCChannelManagerTest`(not active in default, considering about travis-CI performance)
1. Close the channel if new one selected.