### PR TITLE
1. when create the oap server first. the remote client is null or emp…

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/RemoteSenderService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/RemoteSenderService.java
@@ -48,15 +48,21 @@ public class RemoteSenderService implements Service {
         switch (selector) {
             case HashCode:
                 remoteClient = hashCodeSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                if (remoteClient != null) {
+                    remoteClient.push(nextWorkId, streamData);
+                }
                 break;
             case Rolling:
                 remoteClient = rollingSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                if (remoteClient != null) {
+                    remoteClient.push(nextWorkId, streamData);
+                }
                 break;
             case ForeverFirst:
                 remoteClient = foreverFirstSelector.select(clientManager.getRemoteClient(), streamData);
-                remoteClient.push(nextWorkId, streamData);
+                if (remoteClient != null) {
+                    remoteClient.push(nextWorkId, streamData);
+                }
                 break;
         }
     }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/ForeverFirstSelector.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/ForeverFirstSelector.java
@@ -18,10 +18,12 @@
 
 package org.apache.skywalking.oap.server.core.remote.selector;
 
-import java.util.List;
-import org.apache.skywalking.oap.server.core.remote.data.StreamData;
 import org.apache.skywalking.oap.server.core.remote.client.RemoteClient;
-import org.slf4j.*;
+import org.apache.skywalking.oap.server.core.remote.data.StreamData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * @author peng-yongsheng
@@ -31,6 +33,9 @@ public class ForeverFirstSelector implements RemoteClientSelector {
     private static final Logger logger = LoggerFactory.getLogger(ForeverFirstSelector.class);
 
     @Override public RemoteClient select(List<RemoteClient> clients, StreamData streamData) {
+        if (clients == null || clients.size() ==0) {
+            return  null;
+        }
         if (logger.isDebugEnabled()) {
             logger.debug("clients size: {}", clients.size());
         }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/HashCodeSelector.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/HashCodeSelector.java
@@ -18,9 +18,10 @@
 
 package org.apache.skywalking.oap.server.core.remote.selector;
 
-import java.util.List;
-import org.apache.skywalking.oap.server.core.remote.data.StreamData;
 import org.apache.skywalking.oap.server.core.remote.client.RemoteClient;
+import org.apache.skywalking.oap.server.core.remote.data.StreamData;
+
+import java.util.List;
 
 /**
  * @author peng-yongsheng
@@ -28,6 +29,9 @@ import org.apache.skywalking.oap.server.core.remote.client.RemoteClient;
 public class HashCodeSelector implements RemoteClientSelector {
 
     @Override public RemoteClient select(List<RemoteClient> clients, StreamData streamData) {
+        if (clients == null || clients.size() ==0) {
+            return  null;
+        }
         int size = clients.size();
         int selectIndex = Math.abs(streamData.remoteHashCode()) % size;
         return clients.get(selectIndex);

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/RollingSelector.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/remote/selector/RollingSelector.java
@@ -18,9 +18,10 @@
 
 package org.apache.skywalking.oap.server.core.remote.selector;
 
-import java.util.List;
-import org.apache.skywalking.oap.server.core.remote.data.StreamData;
 import org.apache.skywalking.oap.server.core.remote.client.RemoteClient;
+import org.apache.skywalking.oap.server.core.remote.data.StreamData;
+
+import java.util.List;
 
 /**
  * @author peng-yongsheng
@@ -30,6 +31,9 @@ public class RollingSelector implements RemoteClientSelector {
     private int index = 0;
 
     @Override public RemoteClient select(List<RemoteClient> clients, StreamData streamData) {
+        if (clients == null || clients.size() ==0) {
+            return  null;
+        }
         int size = clients.size();
         index++;
         int selectIndex = Math.abs(index) % size;


### PR DESCRIPTION
…ty. so need handle the exception : java.lang.ArithmeticException: / by zero

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
when i first run oap server, it will have the following exception  . I think this is unreasonable and can be prevented from being disposed of.

2019-01-28 06:15:33,614 - org.apache.skywalking.oap.server.core.analysis.worker.IndicatorRemoteWorker - 53 [DataCarrier.IndicatorAggregateWorker.instance_jvm_memory_heap.Consumser.0.Thread] ERROR [] - / by zero
java.lang.ArithmeticException: / by zero
        at org.apache.skywalking.oap.server.core.remote.selector.HashCodeSelector.select(HashCodeSelector.java:32) ~[server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.remote.RemoteSenderService.send(RemoteSenderService.java:50) ~[server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorRemoteWorker.in(IndicatorRemoteWorker.java:51) ~[server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorRemoteWorker.in(IndicatorRemoteWorker.java:33) ~[server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorAggregateWorker.lambda$sendToNext$0(IndicatorAggregateWorker.java:93) ~[server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at java.util.HashMap$Values.forEach(HashMap.java:981) [?:1.8.0_191]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorAggregateWorker.sendToNext(IndicatorAggregateWorker.java:88) [server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorAggregateWorker.onWork(IndicatorAggregateWorker.java:73) [server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorAggregateWorker.access$100(IndicatorAggregateWorker.java:38) [server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.oap.server.core.analysis.worker.IndicatorAggregateWorker$AggregatorConsumer.consume(IndicatorAggregateWorker.java:131) [server-core-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.apm.commons.datacarrier.consumer.ConsumerThread.consume(ConsumerThread.java:101) [apm-datacarrier-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]
        at org.apache.skywalking.apm.commons.datacarrier.consumer.ConsumerThread.run(ConsumerThread.java:68) [apm-datacarrier-6.1.0-SNAPSHOT.jar:6.1.0-SNAPSHOT]

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
