### PR TITLE
Separate the GRPC binding address from the service discovery registry address

### DIFF
--- a/docker/config/application.yml
+++ b/docker/config/application.yml
@@ -38,7 +38,11 @@ core:
     restHost: ${SW_CORE_REST_HOST:0.0.0.0}
     restPort: ${SW_CORE_REST_PORT:12800}
     restContextPath: ${SW_CORE_REST_CONTEXT_PATH:/}
-    gRPCHost: ${SW_CORE_GRPC_HOST:0.0.0.0}
+    # 0.0.0.0 means all IPv4 addresses on the local machine. So, we suggest you bind gRPC address to 0.0.0.0
+    # that let you can connect to this machine by using any IPv4 address of this machine.
+    gRPCBindHost: ${SW_CORE_GRPC_BIND_HOST:0.0.0.0}
+    # Must be specify a LAN address or internet address to let all the OAP servers are reachable to each other.
+    gRPCDiscoveryHost: ${SW_CORE_GRPC_DISCOVERY_HOST:0.0.0.0}
     gRPCPort: ${SW_CORE_GRPC_PORT:11800}
     downsampling:
     - Hour

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleConfig.java
@@ -31,7 +31,8 @@ public class CoreModuleConfig extends ModuleConfig {
     @Setter private String restHost;
     @Setter private int restPort;
     @Setter private String restContextPath;
-    @Setter private String gRPCHost;
+    @Setter private String gRPCBindHost;
+    @Setter private String gRPCDiscoveryHost;
     @Setter private int gRPCPort;
     @Setter private int maxConcurrentCallsPerConnection;
     @Setter private int maxMessageSize;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/CoreModuleProvider.java
@@ -85,7 +85,7 @@ public class CoreModuleProvider extends ModuleProvider {
     }
 
     @Override public void prepare() throws ServiceNotProvidedException {
-        grpcServer = new GRPCServer(moduleConfig.getGRPCHost(), moduleConfig.getGRPCPort());
+        grpcServer = new GRPCServer(moduleConfig.getGRPCBindHost(), moduleConfig.getGRPCPort());
         if (moduleConfig.getMaxConcurrentCallsPerConnection() > 0) {
             grpcServer.setMaxConcurrentCallsPerConnection(moduleConfig.getMaxConcurrentCallsPerConnection());
         }
@@ -165,7 +165,7 @@ public class CoreModuleProvider extends ModuleProvider {
             throw new ModuleStartException(e.getMessage(), e);
         }
 
-        RemoteInstance gRPCServerInstance = new RemoteInstance(new Address(moduleConfig.getGRPCHost(), moduleConfig.getGRPCPort(), true));
+        RemoteInstance gRPCServerInstance = new RemoteInstance(new Address(moduleConfig.getGRPCDiscoveryHost(), moduleConfig.getGRPCPort(), true));
         this.getManager().find(ClusterModule.NAME).provider().getService(ClusterRegister.class).registerRemote(gRPCServerInstance);
 
         PersistenceTimer.INSTANCE.start(getManager());

--- a/oap-server/server-starter/src/main/assembly/application.yml
+++ b/oap-server/server-starter/src/main/assembly/application.yml
@@ -38,7 +38,11 @@ core:
     restHost: ${SW_CORE_REST_HOST:0.0.0.0}
     restPort: ${SW_CORE_REST_PORT:12800}
     restContextPath: ${SW_CORE_REST_CONTEXT_PATH:/}
-    gRPCHost: ${SW_CORE_GRPC_HOST:0.0.0.0}
+    # 0.0.0.0 means all IPv4 addresses on the local machine. So, we suggest you bind gRPC address to 0.0.0.0
+    # that let you can connect to this machine by using any IPv4 address of this machine.
+    gRPCBindHost: ${SW_CORE_GRPC_BIND_HOST:0.0.0.0}
+    # Must be specify a LAN address or internet address to let all the OAP servers are reachable to each other.
+    gRPCDiscoveryHost: ${SW_CORE_GRPC_DISCOVERY_HOST:0.0.0.0}
     gRPCPort: ${SW_CORE_GRPC_PORT:11800}
     downsampling:
     - Hour

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -38,7 +38,11 @@ core:
     restHost: ${SW_CORE_REST_HOST:0.0.0.0}
     restPort: ${SW_CORE_REST_PORT:12800}
     restContextPath: ${SW_CORE_REST_CONTEXT_PATH:/}
-    gRPCHost: ${SW_CORE_GRPC_HOST:0.0.0.0}
+    # 0.0.0.0 means all IPv4 addresses on the local machine. So, we suggest you bind gRPC address to 0.0.0.0
+    # that let you can connect to this machine by using any IPv4 address of this machine.
+    gRPCBindHost: ${SW_CORE_GRPC_BIND_HOST:0.0.0.0}
+    # Must be specify a LAN address or internet address to let all the OAP servers are reachable to each other.
+    gRPCDiscoveryHost: ${SW_CORE_GRPC_DISCOVERY_HOST:0.0.0.0}
     gRPCPort: ${SW_CORE_GRPC_PORT:11800}
     downsampling:
       - Hour


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [X] New feature provided
- [ ] Improve performance

- Related issues
#2217 
___
### New feature or improvement
- Describe the details and related test reports.

#### grpc bind host: 0.0.0.0
127.0.0.1 reachable OAP server
localhost reachable OAP server
0.0.0.0   reachable OAP server
LAN address or Internet address reachable OAP server

#### grpc discovery host: Lan address
OAP servers reachable each other
