### PR TITLE
fixed CPU UsagePercent Error

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/cpu/CPUMetricAccessor.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/cpu/CPUMetricAccessor.java
@@ -46,6 +46,6 @@ public abstract class CPUMetricAccessor {
         long now = System.nanoTime();
 
         CPU.Builder cpuBuilder = CPU.newBuilder();
-        return cpuBuilder.setUsagePercent(cpuCost * 1.0d / ((now - lastSampleTimeNs) * cpuCoreNum)).build();
+        return cpuBuilder.setUsagePercent(cpuCost * 1.0d / ((now - lastSampleTimeNs) * cpuCoreNum) * 100).build();
     }
 }


### PR DESCRIPTION
fixed CPU UsagePercent Error


Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
The cpu usage storage accuracy should be one percent, not one in ten thousand. When the storage unit is one ten thousandth, as long as the usage rate does not exceed 100%. Stored values are less than one. When the current query is forced to be converted to a long type, it will always be 0. This is not correct.
- How to fix?
Cpu usage storage accuracy is one percent

