### PR TITLE
Support to register different host/port at cluster coordinator

### DIFF
--- a/docs/en/setup/backend/backend-cluster.md
+++ b/docs/en/setup/backend/backend-cluster.md
@@ -30,6 +30,22 @@ cluster:
 - `hostPort` is the list of zookeeper servers. Format is `IP1:PORT1,IP2:PORT2,...,IPn:PORTn`
 - `hostPort`, `baseSleepTimeMs` and `maxRetries` are settings of Zookeeper curator client.
 
+In some cases, oap default gRPC host and port in core are not suitable for internal communication among the oap nodes.
+The following setting are provided to set the hot and port manually, based on your own LAN env.
+- internalComHost, the host registered and other oap node use this to communicate with current node.
+- internalComPort, the port registered and other oap node use this to communicate with current node.
+
+```yaml
+zookeeper:
+  nameSpace: ${SW_NAMESPACE:""}
+  hostPort: ${SW_CLUSTER_ZK_HOST_PORT:localhost:2181}
+  #Retry Policy
+  baseSleepTimeMs: ${SW_CLUSTER_ZK_SLEEP_TIME:1000} # initial amount of time to wait between retries
+  maxRetries: ${SW_CLUSTER_ZK_MAX_RETRIES:3} # max number of times to retry
+  internalComHost: 172.10.4.10
+  internalComPort: 8080
+``` 
+
 
 ## Kubernetes
 Require backend cluster are deployed inside kubernetes, guides are in [Deploy in kubernetes](backend-k8s.md).
@@ -56,3 +72,9 @@ cluster:
     # Consul cluster nodes, example: 10.0.0.1:8500,10.0.0.2:8500,10.0.0.3:8500
     hostPort: ${SW_CLUSTER_CONSUL_HOST_PORT:localhost:8500}
 ```
+
+Same as Zookeeper coordinator,
+in some cases, oap default gRPC host and port in core are not suitable for internal communication among the oap nodes.
+The following setting are provided to set the hot and port manually, based on your own LAN env.
+- internalComHost, the host registered and other oap node use this to communicate with current node.
+- internalComPort, the port registered and other oap node use this to communicate with current node.

--- a/docs/en/setup/backend/backend-cluster.md
+++ b/docs/en/setup/backend/backend-cluster.md
@@ -43,7 +43,7 @@ zookeeper:
   baseSleepTimeMs: ${SW_CLUSTER_ZK_SLEEP_TIME:1000} # initial amount of time to wait between retries
   maxRetries: ${SW_CLUSTER_ZK_MAX_RETRIES:3} # max number of times to retry
   internalComHost: 172.10.4.10
-  internalComPort: 8080
+  internalComPort: 11800
 ``` 
 
 

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ClusterModuleConsulConfig.java
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ClusterModuleConsulConfig.java
@@ -27,4 +27,6 @@ import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 class ClusterModuleConsulConfig extends ModuleConfig {
     @Setter @Getter private String serviceName;
     @Setter @Getter private String hostPort;
+    @Setter @Getter private String internalComHost;
+    @Setter @Getter private int internalComPort = -1;
 }

--- a/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ClusterModuleConsulProvider.java
+++ b/oap-server/server-cluster-plugin/cluster-consul-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/consul/ClusterModuleConsulProvider.java
@@ -80,7 +80,7 @@ public class ClusterModuleConsulProvider extends ModuleProvider {
             throw new ModuleStartException(e.getMessage(), e);
         }
 
-        ConsulCoordinator coordinator = new ConsulCoordinator(client, config.getServiceName());
+        ConsulCoordinator coordinator = new ConsulCoordinator(config, client);
         this.registerServiceImplementation(ClusterRegister.class, coordinator);
         this.registerServiceImplementation(ClusterNodesQuery.class, coordinator);
     }

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperConfig.java
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperConfig.java
@@ -31,6 +31,8 @@ class ClusterModuleZookeeperConfig extends ModuleConfig {
     private String hostPort;
     private int baseSleepTimeMs;
     private int maxRetries;
+    @Setter @Getter private String internalComHost;
+    @Setter @Getter private int internalComPort = -1;
 
     public String getHostPort() {
         return Strings.isNullOrEmpty(hostPort) ? "localhost:2181" : hostPort;

--- a/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperProvider.java
+++ b/oap-server/server-cluster-plugin/cluster-zookeeper-plugin/src/main/java/org/apache/skywalking/oap/server/cluster/plugin/zookeeper/ClusterModuleZookeeperProvider.java
@@ -79,7 +79,7 @@ public class ClusterModuleZookeeperProvider extends ModuleProvider {
             throw new ModuleStartException(e.getMessage(), e);
         }
 
-        ZookeeperCoordinator coordinator = new ZookeeperCoordinator(serviceDiscovery);
+        ZookeeperCoordinator coordinator = new ZookeeperCoordinator(config, serviceDiscovery);
         this.registerServiceImplementation(ClusterRegister.class, coordinator);
         this.registerServiceImplementation(ClusterNodesQuery.class, coordinator);
     }


### PR DESCRIPTION
According to #2217 , in some scenarios, the oap server binding address is not suitable for oap cluster internal communication. So, need a different address register at cluster coordinator, like zookeeper and consul.

In #2218, providing another host/port in core module could solve this issue, but could make more confuse, because this is a special case, and most people wouldn't use this. Also, not all cluster management implementation supports in this way, such as k8s.

In this pull request, I add two optional settings in zookeeper and consul cluster coordinator.
- internalComHost
- internalComPort

Default they are inactive, if you active them manually, the coordinator use these to notify other oap node, when they do internal communication, to instead `gRPCHost` and `gRPCPort`.