### PR TITLE
When creating elastic search index, the index that can delete histori…

### DIFF
--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/query/TraceQueryService.java
@@ -35,6 +35,7 @@ import org.apache.skywalking.oap.server.core.storage.query.ITraceQueryDAO;
 import org.apache.skywalking.oap.server.library.module.Service;
 import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.util.CollectionUtils;
+import org.joda.time.DateTime;
 
 import static java.util.Objects.nonNull;
 
@@ -102,7 +103,9 @@ public class TraceQueryService implements Service {
     public Trace queryTrace(final String traceId) throws IOException {
         Trace trace = new Trace();
 
-        List<SegmentRecord> segmentRecords = getTraceQueryDAO().queryByTraceId(traceId);
+        String[] idBT = traceId.split("_");
+        Long time =  Long.valueOf(new DateTime(Long.parseLong(idBT[1])).toString("yyyyMMddHHmmss"));
+        List<SegmentRecord> segmentRecords = getTraceQueryDAO().queryByTraceId(idBT[0], time, time);
         for (SegmentRecord segment : segmentRecords) {
             if (nonNull(segment)) {
                 if (segment.getVersion() == 2) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/IHistoryDeleteDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/IHistoryDeleteDAO.java
@@ -18,7 +18,10 @@
 
 package org.apache.skywalking.oap.server.core.storage;
 
+import org.apache.skywalking.oap.server.core.storage.model.Model;
+
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author peng-yongsheng
@@ -26,4 +29,6 @@ import java.io.IOException;
 public interface IHistoryDeleteDAO extends DAO {
 
     void deleteHistory(String modelName, String timeBucketColumnName, Long timeBucketBefore) throws IOException;
+
+    void historyOther(List<Model> models, long otherDataTTL);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelInstaller.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/model/ModelInstaller.java
@@ -59,6 +59,7 @@ public abstract class ModelInstaller {
             }
         });
         allModels.addAll(models);
+        allModels.addAll(getOtherModels(allModels, client));
 
         boolean debug = System.getProperty("debug") != null;
 
@@ -85,6 +86,10 @@ public abstract class ModelInstaller {
                 columnCheck(client, model);
             }
         }
+    }
+
+    protected List<Model> getOtherModels(List<Model> model, Client client) {
+        return new ArrayList<>();
     }
 
     public final void overrideColumnName(String columnName, String newName) {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITraceQueryDAO.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/query/ITraceQueryDAO.java
@@ -33,5 +33,5 @@ public interface ITraceQueryDAO extends Service {
         long maxDuration, String endpointName, int serviceId, int serviceInstanceId, int endpointId, String traceId,
         int limit, int from, TraceState traceState, QueryOrder queryOrder) throws IOException;
 
-    List<SegmentRecord> queryByTraceId(String traceId) throws IOException;
+    List<SegmentRecord> queryByTraceId(String traceId, long startSecondTB, long endSecondTB) throws IOException;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/ttl/DataTTLKeeperTimer.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/storage/ttl/DataTTLKeeperTimer.java
@@ -65,9 +65,7 @@ public enum DataTTLKeeperTimer {
             new RunnableWithExceptionProtection(this::delete,
                 t -> logger.error("Remove data in background failure.", t)), 1, 5, TimeUnit.MINUTES);
 
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                new RunnableWithExceptionProtection(this::deleteAndCreateOther,
-                        t -> logger.error("delete index in background failure.", t)), 1, 2, TimeUnit.HOURS);
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(new RunnableWithExceptionProtection(this::deleteAndCreateOther, t -> logger.error("delete index in background failure.", t)), 1, 2, TimeUnit.HOURS);
     }
 
     private void deleteAndCreateOther() {

--- a/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchUtil.java
+++ b/oap-server/server-library/library-client/src/main/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.library.client.elasticsearch;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * @author ye-erpeng
+ */
+public class ElasticSearchUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(ElasticSearchUtil.class);
+
+
+    public static String[] getEsIndexByDate(String tableName, Long startTime, Long endTime) {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+        try {
+            Date starts = formatter.parse(startTime.toString().substring(0, 8));
+            Date ends = formatter.parse(endTime.toString().substring(0, 8));
+            long length = (ends.getTime() - starts.getTime()) / (24 * 60 * 60 * 1000);
+            if (length < 1) {
+                length = 0;
+            }
+            String[] rs = new String[(int)length + 1];
+            for (int j = 0; j < rs.length; j++) {
+                rs[j] = tableName + "_" + formatter.format(DateUtils.addDays(starts, j));
+            }
+            return rs;
+        } catch (Exception e) {
+            logger.error("get indexes by date range error, error message: {}", e.getMessage());
+        }
+        return null;
+    }
+}

--- a/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClientTestCase.java
+++ b/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ElasticSearchClientTestCase.java
@@ -47,7 +47,7 @@ public class ElasticSearchClientTestCase {
             .endObject();
         builder.endObject();
 
-        ElasticSearchClient client = new ElasticSearchClient("localhost:9200", null);
+        ElasticSearchClient client = new ElasticSearchClient("localhost:9200", null, null);
         client.connect();
 
         String indexName = "test";

--- a/oap-server/server-starter/src/main/assembly/application.yml
+++ b/oap-server/server-starter/src/main/assembly/application.yml
@@ -65,6 +65,7 @@ storage:
 #    bulkSize: ${SW_STORAGE_ES_BULK_SIZE:20} # flush the bulk every 20mb
 #    flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
 #    concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+#    createByDayIndexes: ${SW_STORAGE_ES_CREATE_BY_DAY_INDEXES:""} # create index by day,for indexes that can delete historical data only
 #  mysql:
 receiver-register:
   default:

--- a/oap-server/server-starter/src/main/resources/application.yml
+++ b/oap-server/server-starter/src/main/resources/application.yml
@@ -61,6 +61,7 @@ storage:
     bulkSize: ${SW_STORAGE_ES_BULK_SIZE:20} # flush the bulk every 20mb
     flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
     concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+    createByDayIndexes: ${SW_STORAGE_ES_CREATE_BY_DAY_INDEXES:segment} # create index by day,for indexes that can delete historical data only
 #  h2:
 #    driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
 #    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/StorageModuleElasticsearchConfig.java
@@ -28,6 +28,7 @@ public class StorageModuleElasticsearchConfig extends ModuleConfig {
 
     @Setter @Getter private String nameSpace;
     @Setter @Getter private String clusterNodes;
+    @Setter @Getter private String createByDayIndexes;
     private int indexShardsNumber;
     private int indexReplicasNumber;
     private boolean highPerformanceMode;

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/HistoryDeleteEsDAO.java
@@ -18,12 +18,18 @@
 
 package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
 
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
+import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.storage.model.Model;
 import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -33,8 +39,11 @@ public class HistoryDeleteEsDAO extends EsDAO implements IHistoryDeleteDAO {
 
     private static final Logger logger = LoggerFactory.getLogger(HistoryDeleteEsDAO.class);
 
-    public HistoryDeleteEsDAO(ElasticSearchClient client) {
+    private final StorageEsInstaller storageEsInstaller;
+
+    public HistoryDeleteEsDAO(ElasticSearchClient client, StorageEsInstaller storageEsInstaller) {
         super(client);
+        this.storageEsInstaller = storageEsInstaller;
     }
 
     @Override
@@ -44,5 +53,70 @@ public class HistoryDeleteEsDAO extends EsDAO implements IHistoryDeleteDAO {
         if (logger.isDebugEnabled()) {
             logger.debug("Delete history from {} index, status code {}", client.formatIndexName(modelName), statusCode);
         }
+    }
+
+    @Override
+    public void historyOther(List<Model> models, long otherDataTTL) {
+
+        List<Model> tables = new ArrayList<>();
+
+        ElasticSearchClient client = getClient();
+        models.forEach(module -> {
+            if (client.getCreateByDayIndexes().contains(module.getName())) {
+                tables.add(module);
+            }
+        });
+
+        DateTime currentTime = new DateTime();
+
+        tables.forEach(module -> {
+            for (int i = 1; i <= 3; i++) {
+                deleteIndex(client, module.getName() + Const.ID_SPLIT + currentTime.plusDays(-i).toString("yyyyMMdd"));
+            }
+
+            for (int i = 0; i <= 2; i++) {
+                createIndex(client, module.copy(module.getName() + Const.ID_SPLIT + currentTime.plusDays(i).toString("yyyyMMdd")));
+            }
+        });
+    }
+
+    private void deleteIndex(ElasticSearchClient client, String indexName) {
+        try {
+            if (client.isExistsIndex(indexName)) {
+                boolean statusCode = false;
+                try {
+                    statusCode = client.deleteIndex(indexName);
+                } catch (IOException e) {
+                    logger.warn("index of {} delete failure", indexName);
+                    logger.error(e.getMessage(), e);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Delete history {} index, status code {}", indexName, statusCode);
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("index of {} delete failure", indexName);
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    private void createIndex(ElasticSearchClient client, Model model) {
+        try {
+            if (!client.isExistsIndex(model.getName())) {
+                try {
+                    storageEsInstaller.createTable(client, model);
+                } catch (StorageException e) {
+                    logger.warn("index of {} create failure", model.getName());
+                    logger.error(e.getMessage(), e);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("index of {} create success", model.getName());
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("index of {} delete failure", model.getName());
+            logger.error(e.getMessage(), e);
+        }
+
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndicatorEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/IndicatorEsDAO.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
 
 import java.io.IOException;
 import java.util.Map;
+
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.analysis.indicator.Indicator;
 import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.core.storage.type.StorageDataType;
@@ -66,7 +68,11 @@ public class IndicatorEsDAO extends EsDAO implements IIndicatorDAO<IndexRequest,
             }
         }
         builder.endObject();
-        return getClient().prepareInsert(modelName, indicator.id(), builder);
+        ElasticSearchClient client = getClient();
+        if (client.getCreateByDayIndexes().contains(modelName)) {
+            modelName = modelName + Const.ID_SPLIT + (indicator.getTimeBucket() + "").substring(0, 8);
+        }
+        return client.prepareInsert(modelName, indicator.id(), builder);
     }
 
     @Override public UpdateRequest prepareBatchUpdate(String modelName, Indicator indicator) throws IOException {
@@ -82,6 +88,10 @@ public class IndicatorEsDAO extends EsDAO implements IIndicatorDAO<IndexRequest,
             }
         }
         builder.endObject();
-        return getClient().prepareUpdate(modelName, indicator.id(), builder);
+        ElasticSearchClient client = getClient();
+        if (client.getCreateByDayIndexes().contains(modelName)) {
+            modelName = modelName + Const.ID_SPLIT + (indicator.getTimeBucket() + "").substring(0, 8);
+        }
+        return client.prepareUpdate(modelName, indicator.id(), builder);
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/RecordEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/base/RecordEsDAO.java
@@ -20,6 +20,8 @@ package org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base;
 
 import java.io.IOException;
 import java.util.Map;
+
+import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.core.analysis.record.Record;
 import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.core.storage.type.StorageDataType;
@@ -52,6 +54,10 @@ public class RecordEsDAO extends EsDAO implements IRecordDAO<IndexRequest> {
             }
         }
         builder.endObject();
-        return getClient().prepareInsert(modelName, record.id(), builder);
+        ElasticSearchClient client = getClient();
+        if (client.getCreateByDayIndexes().contains(modelName)) {
+            modelName = modelName + Const.ID_SPLIT + (record.getTimeBucket() + "").substring(0, 8);
+        }
+        return client.prepareInsert(modelName, record.id(), builder);
     }
 }

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/EndpointInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/EndpointInventoryCacheEsDAO.java
@@ -64,7 +64,7 @@ public class EndpointInventoryCacheEsDAO extends EsDAO implements IEndpointInven
             searchSourceBuilder.query(QueryBuilders.termQuery(EndpointInventory.SEQUENCE, endpointId));
             searchSourceBuilder.size(1);
 
-            SearchResponse response = getClient().search(EndpointInventory.MODEL_NAME, searchSourceBuilder);
+            SearchResponse response = getClient().search(new String[]{EndpointInventory.MODEL_NAME}, searchSourceBuilder);
             if (response.getHits().totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/NetworkAddressInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/NetworkAddressInventoryCacheEsDAO.java
@@ -64,7 +64,7 @@ public class NetworkAddressInventoryCacheEsDAO extends EsDAO implements INetwork
             searchSourceBuilder.query(QueryBuilders.termQuery(NetworkAddressInventory.SEQUENCE, addressId));
             searchSourceBuilder.size(1);
 
-            SearchResponse response = getClient().search(NetworkAddressInventory.MODEL_NAME, searchSourceBuilder);
+            SearchResponse response = getClient().search(new String[]{NetworkAddressInventory.MODEL_NAME}, searchSourceBuilder);
             if (response.getHits().totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInstanceInventoryCacheDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInstanceInventoryCacheDAO.java
@@ -49,7 +49,7 @@ public class ServiceInstanceInventoryCacheDAO extends EsDAO implements IServiceI
             searchSourceBuilder.query(QueryBuilders.termQuery(ServiceInstanceInventory.SEQUENCE, serviceInstanceId));
             searchSourceBuilder.size(1);
 
-            SearchResponse response = getClient().search(ServiceInstanceInventory.MODEL_NAME, searchSourceBuilder);
+            SearchResponse response = getClient().search(new String[]{ServiceInstanceInventory.MODEL_NAME}, searchSourceBuilder);
             if (response.getHits().totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/cache/ServiceInventoryCacheEsDAO.java
@@ -75,7 +75,7 @@ public class ServiceInventoryCacheEsDAO extends EsDAO implements IServiceInvento
             searchSourceBuilder.query(QueryBuilders.termQuery(ServiceInventory.SEQUENCE, serviceId));
             searchSourceBuilder.size(1);
 
-            SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, searchSourceBuilder);
+            SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, searchSourceBuilder);
             if (response.getHits().totalHits == 1) {
                 SearchHit searchHit = response.getHits().getAt(0);
                 return builder.map2Data(searchHit.getSourceAsMap());
@@ -101,7 +101,7 @@ public class ServiceInventoryCacheEsDAO extends EsDAO implements IServiceInvento
             searchSourceBuilder.query(boolQuery);
             searchSourceBuilder.size(50);
 
-            SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, searchSourceBuilder);
+            SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, searchSourceBuilder);
 
             for (SearchHit searchHit : response.getHits().getHits()) {
                 serviceInventories.add(this.builder.map2Data(searchHit.getSourceAsMap()));

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AlarmQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/AlarmQueryEsDAO.java
@@ -61,7 +61,9 @@ public class AlarmQueryEsDAO extends EsDAO implements IAlarmQueryDAO {
         sourceBuilder.size(limit);
         sourceBuilder.from(from);
 
-        SearchResponse response = getClient().search(AlarmRecord.INDEX_NAME, sourceBuilder);
+        ElasticSearchClient client = getClient();
+        String[] indexes = client.getIndexNameByDate(AlarmRecord.INDEX_NAME, startTB, endTB);
+        SearchResponse response = client.search(indexes, sourceBuilder);
 
         Alarms alarms = new Alarms();
         alarms.setTotal((int)response.getHits().totalHits);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java
@@ -60,7 +60,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(0);
 
-        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, sourceBuilder);
         return (int)response.getHits().getTotalHits();
     }
 
@@ -74,7 +74,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(0);
 
-        SearchResponse response = getClient().search(EndpointInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{EndpointInventory.MODEL_NAME}, sourceBuilder);
         return (int)response.getHits().getTotalHits();
     }
 
@@ -85,7 +85,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(QueryBuilders.termQuery(ServiceInventory.NODE_TYPE, nodeTypeValue));
         sourceBuilder.size(0);
 
-        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, sourceBuilder);
 
         return (int)response.getHits().getTotalHits();
     }
@@ -102,7 +102,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(100);
 
-        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, sourceBuilder);
 
         return buildServices(response);
     }
@@ -117,7 +117,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(100);
 
-        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, sourceBuilder);
 
         List<Database> databases = new ArrayList<>();
         for (SearchHit searchHit : response.getHits()) {
@@ -155,7 +155,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(100);
 
-        SearchResponse response = getClient().search(ServiceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInventory.MODEL_NAME}, sourceBuilder);
         return buildServices(response);
     }
 
@@ -189,7 +189,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(limit);
 
-        SearchResponse response = getClient().search(EndpointInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{EndpointInventory.MODEL_NAME}, sourceBuilder);
 
         List<Endpoint> endpoints = new ArrayList<>();
         for (SearchHit searchHit : response.getHits()) {
@@ -216,7 +216,7 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(100);
 
-        SearchResponse response = getClient().search(ServiceInstanceInventory.MODEL_NAME, sourceBuilder);
+        SearchResponse response = getClient().search(new String[]{ServiceInstanceInventory.MODEL_NAME}, sourceBuilder);
 
         List<ServiceInstance> serviceInstances = new ArrayList<>();
         for (SearchHit searchHit : response.getHits()) {

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetricQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetricQueryEsDAO.java
@@ -56,7 +56,9 @@ public class MetricQueryEsDAO extends EsDAO implements IMetricQueryDAO {
 
         sourceBuilder.aggregation(entityIdAggregation);
 
-        SearchResponse response = getClient().search(indexName, sourceBuilder);
+        ElasticSearchClient client = getClient();
+        String[] indexes = client.getIndexNameByDate(indexName, startTB, endTB);
+        SearchResponse response = client.search(indexes, sourceBuilder);
 
         IntValues intValues = new IntValues();
         Terms idTerms = response.getAggregations().get(Indicator.ENTITY_ID);

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TopNRecordsQueryEsDAO.java
@@ -49,7 +49,9 @@ public class TopNRecordsQueryEsDAO extends EsDAO implements ITopNRecordsQueryDAO
 
         sourceBuilder.query(boolQueryBuilder);
         sourceBuilder.size(topN).sort(TopN.LATENCY, order.equals(Order.DES) ? SortOrder.DESC : SortOrder.ASC);
-        SearchResponse response = getClient().search(metricName, sourceBuilder);
+        ElasticSearchClient client = getClient();
+        String[] indexes = client.getIndexNameByDate(metricName, startSecondTB, endSecondTB);
+        SearchResponse response = client.search(indexes, sourceBuilder);
 
         List<TopNRecord> results = new ArrayList<>();
 

--- a/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
+++ b/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/TraceQueryEsDAO.java
@@ -100,7 +100,9 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         sourceBuilder.size(limit);
         sourceBuilder.from(from);
 
-        SearchResponse response = getClient().search(SegmentRecord.INDEX_NAME, sourceBuilder);
+        ElasticSearchClient client = getClient();
+        String[] indexes = client.getIndexNameByDate(SegmentRecord.INDEX_NAME, startSecondTB, endSecondTB);
+        SearchResponse response = client.search(indexes, sourceBuilder);
 
         TraceBrief traceBrief = new TraceBrief();
         traceBrief.setTotal((int)response.getHits().totalHits);
@@ -120,12 +122,14 @@ public class TraceQueryEsDAO extends EsDAO implements ITraceQueryDAO {
         return traceBrief;
     }
 
-    @Override public List<SegmentRecord> queryByTraceId(String traceId) throws IOException {
+    @Override public List<SegmentRecord> queryByTraceId(String traceId, long startSecondTB, long endSecondTB) throws IOException {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource();
         sourceBuilder.query(QueryBuilders.termQuery(SegmentRecord.TRACE_ID, traceId));
         sourceBuilder.size(20);
 
-        SearchResponse response = getClient().search(SegmentRecord.INDEX_NAME, sourceBuilder);
+        ElasticSearchClient client = getClient();
+        String[] indexes = client.getIndexNameByDate(SegmentRecord.INDEX_NAME, startSecondTB, endSecondTB);
+        SearchResponse response = client.search(indexes, sourceBuilder);
 
         List<SegmentRecord> segmentRecords = new ArrayList<>();
         for (SearchHit searchHit : response.getHits().getHits()) {

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2HistoryDeleteDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2HistoryDeleteDAO.java
@@ -21,7 +21,10 @@ package org.apache.skywalking.oap.server.storage.plugin.jdbc.h2.dao;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
+
 import org.apache.skywalking.oap.server.core.storage.IHistoryDeleteDAO;
+import org.apache.skywalking.oap.server.core.storage.model.Model;
 import org.apache.skywalking.oap.server.library.client.jdbc.JDBCClientException;
 import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCHikariCPClient;
 import org.apache.skywalking.oap.server.storage.plugin.jdbc.SQLBuilder;
@@ -45,5 +48,10 @@ public class H2HistoryDeleteDAO implements IHistoryDeleteDAO {
         } catch (JDBCClientException | SQLException e) {
             throw new IOException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void historyOther(List<Model> models, long otherDataTTL) {
+
     }
 }

--- a/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TraceQueryDAO.java
+++ b/oap-server/server-storage-plugin/storage-jdbc-hikaricp-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/jdbc/h2/dao/H2TraceQueryDAO.java
@@ -137,7 +137,7 @@ public class H2TraceQueryDAO implements ITraceQueryDAO {
         sql.append(" OFFSET ").append(from);
     }
 
-    @Override public List<SegmentRecord> queryByTraceId(String traceId) throws IOException {
+    @Override public List<SegmentRecord> queryByTraceId(String traceId, long startSecondTB, long endSecondTB) throws IOException {
         List<SegmentRecord> segmentRecords = new ArrayList<>();
         try (Connection connection = h2Client.getConnection()) {
 


### PR DESCRIPTION
When creating elastic search index, the index that can delete historical data can be created by day by configuration control. When deleting historical data, the index can be deleted directly, which improves the performance of elastic search.

Please answer these questions before submitting pull request

- Why submit this pull request?
New feature provided

- Related issues

___
### New feature or improvement
- Describe the details and related test reports.
When creating elastic search index, the index that can delete historical data can be created by day by configuration control. When deleting historical data, the index can be deleted directly, which improves the performance of elastic search.
The TraceQueryService.queryTrace method has changed in the UI layer. See the UI submission for details.