### PR TITLE
Fix Spring Annotation Plugin (Also Inherit Issue)

### DIFF
--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/annotations/AbstractSpringBeanInstrumentation.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/annotations/AbstractSpringBeanInstrumentation.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.plugin.spring.annotations;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.DeclaredInstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
 
@@ -32,7 +33,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 public abstract class AbstractSpringBeanInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
     private static final String INTERCEPTOR_CLASS = "org.apache.skywalking.apm.plugin.spring.annotations.SpringAnnotationInterceptor";
     public static final String INTERCEPT_GET_SKYWALKING_DYNAMIC_FIELD_METHOD = "getSkyWalkingDynamicField";
-    public static final String INTERCEPT_SET_SKYWALKING_DYNAMIC_FEILD_METHOD = "setSkyWalkingDynamicField";
+    public static final String INTERCEPT_SET_SKYWALKING_DYNAMIC_FIELD_METHOD = "setSkyWalkingDynamicField";
 
     @Override protected final ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
         return new ConstructorInterceptPoint[0];
@@ -40,9 +41,9 @@ public abstract class AbstractSpringBeanInstrumentation extends ClassInstanceMet
 
     @Override protected final InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
         return new InstanceMethodsInterceptPoint[] {
-            new InstanceMethodsInterceptPoint() {
+            new DeclaredInstanceMethodsInterceptPoint() {
                 @Override public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                    return isPublic().and(not(isDeclaredBy(Object.class)).and(not(named(INTERCEPT_GET_SKYWALKING_DYNAMIC_FIELD_METHOD))).and(not(named(INTERCEPT_SET_SKYWALKING_DYNAMIC_FEILD_METHOD))));
+                    return isPublic().and(not(isDeclaredBy(Object.class)).and(not(named(INTERCEPT_GET_SKYWALKING_DYNAMIC_FIELD_METHOD))).and(not(named(INTERCEPT_SET_SKYWALKING_DYNAMIC_FIELD_METHOD))));
                 }
 
                 @Override public String getMethodsInterceptor() {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#2308 
___
### Bug fix
- Bug description.
servicecombe NPE when use spring-annotation-plugin.
- How to fix?
use `DeclaredInstanceMethodsInterceptPoint ` instead of `InstanceMethodsInterceptPoint ` to prevent enhance parent method. (servicecombe framework has many spring annotation and hierarchy relations)

after fixed,enhanced methods are below which not contain the `setSchemaLoader `,that as our expected.
```
static {
        ClassLoader.getSystemClassLoader().loadClass("org.apache.skywalking.apm.dependencies.net.bytebuddy.dynamic.Nexus").getMethod("initialize", Class.class, Integer.TYPE).invoke((Object)null, ProducerSchemaFactory.class, 831121445);
        cachedValue$YscvAqFk$6e6svp1 = ProducerSchemaFactory.class.getMethod("getOrCreateProducerSchema", String.class, Class.class, Object.class);
        cachedValue$YscvAqFk$u2pnf53 = ProducerSchemaFactory.class.getMethod("setSwaggerEnv", SwaggerEnvironment.class);
        LOGGER = LoggerFactory.getLogger(ProducerSchemaFactory.class);
    }
```
original code are below in parent class:
```java
 @Inject
  public void setSchemaLoader(SchemaLoader schemaLoader) {
    this.schemaLoader = schemaLoader;
  }

```
If child class enchance parent class method, the annotation will disappare that make the functional error
___
### New feature or improvement
- Describe the details and related test reports.
