### PR TITLE
Wrong default field in all service instance related scope

### DIFF
--- a/oap-server/generated-analysis/src/main/resources/generator-scope-meta.yml
+++ b/oap-server/generated-analysis/src/main/resources/generator-scope-meta.yml
@@ -52,8 +52,8 @@ scopes:
       columnName: entity_id
       typeName: java.lang.String
       ID: true
-    - fieldName: serviceInstanceId
-      columnName: service_instance_id
+    - fieldName: serviceId
+      columnName: service_id
       typeName: int
       ID: false
   - name: ServiceInstanceJVMMemory
@@ -62,8 +62,8 @@ scopes:
       columnName: entity_id
       typeName: java.lang.String
       ID: true
-    - fieldName: serviceInstanceId
-      columnName: service_instance_id
+    - fieldName: serviceId
+      columnName: service_id
       typeName: int
       ID: false
   - name: ServiceInstanceJVMMemoryPool
@@ -72,8 +72,8 @@ scopes:
       columnName: entity_id
       typeName: java.lang.String
       ID: true
-    - fieldName: serviceInstanceId
-      columnName: service_instance_id
+    - fieldName: serviceId
+      columnName: service_id
       typeName: int
       ID: false
   - name: ServiceInstanceJVMGC
@@ -82,8 +82,8 @@ scopes:
       columnName: entity_id
       typeName: java.lang.String
       ID: true
-    - fieldName: serviceInstanceId
-      columnName: service_instance_id
+    - fieldName: serviceId
+      columnName: service_id
       typeName: int
       ID: false
   - name: ServiceRelation
@@ -140,8 +140,8 @@ scopes:
         columnName: entity_id
         typeName: java.lang.String
         ID: true
-      - fieldName: serviceInstanceId
-        columnName: service_instance_id
+      - fieldName: serviceId
+        columnName: service_id
         typeName: int
         ID: false
   - name: ServiceInstanceCLRGC
@@ -150,8 +150,8 @@ scopes:
         columnName: entity_id
         typeName: java.lang.String
         ID: true
-      - fieldName: serviceInstanceId
-        columnName: service_instance_id
+      - fieldName: serviceId
+        columnName: service_id
         typeName: int
         ID: false
   - name: ServiceInstanceCLRThread
@@ -160,8 +160,8 @@ scopes:
         columnName: entity_id
         typeName: java.lang.String
         ID: true
-      - fieldName: serviceInstanceId
-        columnName: service_instance_id
+      - fieldName: serviceId
+        columnName: service_id
         typeName: int
         ID: false
   - name: EnvoyInstanceMetric
@@ -170,7 +170,7 @@ scopes:
       columnName: entity_id
       typeName: java.lang.String
       ID: true
-    - fieldName: serviceInstanceId
-      columnName: service_instance_id
+    - fieldName: serviceId
+      columnName: service_id
       typeName: int
       ID: false

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EnvoyInstanceMetric.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EnvoyInstanceMetric.java
@@ -44,7 +44,6 @@ public class EnvoyInstanceMetric extends Source {
      */
     @Getter @Setter private int id;
     @Getter @Setter private int serviceId;
-    @Getter @Setter private int serviceInstanceId;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
     @Getter @Setter private String metricName;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRCPU.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRCPU.java
@@ -39,6 +39,6 @@ public class ServiceInstanceCLRCPU extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private double usePercent;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRGC.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRGC.java
@@ -39,7 +39,7 @@ public class ServiceInstanceCLRGC extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private int gen0CollectCount;
     @Getter @Setter private int gen1CollectCount;
     @Getter @Setter private int gen2CollectCount;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRThread.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRThread.java
@@ -39,7 +39,7 @@ public class ServiceInstanceCLRThread extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private long availableCompletionPortThreads;
     @Getter @Setter private long availableWorkerThreads;
     @Getter @Setter private long maxCompletionPortThreads;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMCPU.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMCPU.java
@@ -38,6 +38,6 @@ public class ServiceInstanceJVMCPU extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private double usePercent;
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMGC.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMGC.java
@@ -38,7 +38,7 @@ public class ServiceInstanceJVMGC extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private GCPhrase phrase;
     @Getter @Setter private long time;
     @Getter @Setter private long count;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
@@ -38,7 +38,7 @@ public class ServiceInstanceJVMMemory extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private boolean heapStatus;
     @Getter @Setter private long init;
     @Getter @Setter private long max;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemoryPool.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemoryPool.java
@@ -38,7 +38,7 @@ public class ServiceInstanceJVMMemoryPool extends Source {
     @Getter @Setter private int id;
     @Getter @Setter private String name;
     @Getter @Setter private String serviceName;
-    @Getter @Setter private int serviceInstanceId;
+    @Getter @Setter private int serviceId;
     @Getter @Setter private MemoryPoolType poolType;
     @Getter @Setter private long init;
     @Getter @Setter private long max;

--- a/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/MetricServiceGRPCHandler.java
+++ b/oap-server/server-receiver-plugin/envoy-metrics-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/envoy/MetricServiceGRPCHandler.java
@@ -113,7 +113,6 @@ public class MetricServiceGRPCHandler extends MetricsServiceGrpc.MetricsServiceI
                                         metricSource.setServiceId(serviceId);
                                         metricSource.setServiceName(serviceName);
                                         metricSource.setId(serviceInstanceId);
-                                        metricSource.setServiceInstanceId(serviceInstanceId);
                                         metricSource.setName(serviceInstanceName);
                                         metricSource.setMetricName(metricFamily.getName());
                                         metricSource.setValue(value);

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricReportServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricReportServiceHandler.java
@@ -20,15 +20,11 @@ package org.apache.skywalking.oap.server.receiver.jvm.provider.handler;
 
 import io.grpc.stub.StreamObserver;
 import org.apache.skywalking.apm.network.common.Commands;
-import org.apache.skywalking.apm.network.language.agent.v2.JVMMetricCollection;
-import org.apache.skywalking.apm.network.language.agent.v2.JVMMetricReportServiceGrpc;
-import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.source.SourceReceiver;
+import org.apache.skywalking.apm.network.language.agent.v2.*;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 import org.apache.skywalking.oap.server.library.util.TimeBucketUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
 public class JVMMetricReportServiceHandler extends JVMMetricReportServiceGrpc.JVMMetricReportServiceImplBase implements GRPCHandler {
 
@@ -37,7 +33,7 @@ public class JVMMetricReportServiceHandler extends JVMMetricReportServiceGrpc.JV
     private final JVMSourceDispatcher jvmSourceDispatcher;
 
     public JVMMetricReportServiceHandler(ModuleManager moduleManager) {
-        this.jvmSourceDispatcher = new JVMSourceDispatcher(moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class));
+        this.jvmSourceDispatcher = new JVMSourceDispatcher(moduleManager);
     }
 
     @Override public void collect(JVMMetricCollection request, StreamObserver<Commands> responseObserver) {

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricsServiceHandler.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMMetricsServiceHandler.java
@@ -19,16 +19,11 @@
 package org.apache.skywalking.oap.server.receiver.jvm.provider.handler;
 
 import io.grpc.stub.StreamObserver;
-import org.apache.skywalking.apm.network.language.agent.Downstream;
-import org.apache.skywalking.apm.network.language.agent.JVMMetrics;
-import org.apache.skywalking.apm.network.language.agent.JVMMetricsServiceGrpc;
-import org.apache.skywalking.oap.server.core.CoreModule;
-import org.apache.skywalking.oap.server.core.source.SourceReceiver;
+import org.apache.skywalking.apm.network.language.agent.*;
 import org.apache.skywalking.oap.server.library.module.ModuleManager;
 import org.apache.skywalking.oap.server.library.server.grpc.GRPCHandler;
 import org.apache.skywalking.oap.server.library.util.TimeBucketUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
 /**
  * @author peng-yongsheng
@@ -40,7 +35,7 @@ public class JVMMetricsServiceHandler extends JVMMetricsServiceGrpc.JVMMetricsSe
     private final JVMSourceDispatcher jvmSourceDispatcher;
 
     public JVMMetricsServiceHandler(ModuleManager moduleManager) {
-        this.jvmSourceDispatcher = new JVMSourceDispatcher(moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class));
+        this.jvmSourceDispatcher = new JVMSourceDispatcher(moduleManager);
     }
 
     @Override public void collect(JVMMetrics request, StreamObserver<Downstream> responseObserver) {

--- a/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMSourceDispatcher.java
+++ b/oap-server/server-receiver-plugin/skywalking-jvm-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/jvm/provider/handler/JVMSourceDispatcher.java
@@ -19,54 +19,61 @@
 package org.apache.skywalking.oap.server.receiver.jvm.provider.handler;
 
 import java.util.List;
-import org.apache.skywalking.apm.network.language.agent.CPU;
-import org.apache.skywalking.apm.network.language.agent.GC;
-import org.apache.skywalking.apm.network.language.agent.JVMMetric;
-import org.apache.skywalking.apm.network.language.agent.Memory;
-import org.apache.skywalking.apm.network.language.agent.MemoryPool;
-import org.apache.skywalking.oap.server.core.Const;
+import org.apache.skywalking.apm.network.language.agent.*;
+import org.apache.skywalking.oap.server.core.*;
+import org.apache.skywalking.oap.server.core.cache.ServiceInstanceInventoryCache;
+import org.apache.skywalking.oap.server.core.register.ServiceInstanceInventory;
 import org.apache.skywalking.oap.server.core.source.GCPhrase;
-import org.apache.skywalking.oap.server.core.source.MemoryPoolType;
-import org.apache.skywalking.oap.server.core.source.ServiceInstanceJVMCPU;
-import org.apache.skywalking.oap.server.core.source.ServiceInstanceJVMGC;
-import org.apache.skywalking.oap.server.core.source.ServiceInstanceJVMMemory;
-import org.apache.skywalking.oap.server.core.source.ServiceInstanceJVMMemoryPool;
-import org.apache.skywalking.oap.server.core.source.SourceReceiver;
+import org.apache.skywalking.oap.server.core.source.*;
+import org.apache.skywalking.oap.server.library.module.ModuleManager;
+import org.slf4j.*;
 
 /**
  * @author wusheng
  */
 public class JVMSourceDispatcher {
-    private SourceReceiver sourceReceiver;
+    private static final Logger logger = LoggerFactory.getLogger(JVMSourceDispatcher.class);
+    private final SourceReceiver sourceReceiver;
+    private final ServiceInstanceInventoryCache instanceInventoryCache;
 
-    public JVMSourceDispatcher(SourceReceiver sourceReceiver) {
-        this.sourceReceiver = sourceReceiver;
+    public JVMSourceDispatcher(ModuleManager moduleManager) {
+        this.sourceReceiver = moduleManager.find(CoreModule.NAME).provider().getService(SourceReceiver.class);
+        instanceInventoryCache = moduleManager.find(CoreModule.NAME).provider().getService(ServiceInstanceInventoryCache.class);
     }
 
     void sendMetric(int serviceInstanceId, long minuteTimeBucket, JVMMetric metric) {
-        this.sendToCpuMetricProcess(serviceInstanceId, minuteTimeBucket, metric.getCpu());
-        this.sendToMemoryMetricProcess(serviceInstanceId, minuteTimeBucket, metric.getMemoryList());
-        this.sendToMemoryPoolMetricProcess(serviceInstanceId, minuteTimeBucket, metric.getMemoryPoolList());
-        this.sendToGCMetricProcess(serviceInstanceId, minuteTimeBucket, metric.getGcList());
+        ServiceInstanceInventory serviceInstanceInventory = instanceInventoryCache.get(serviceInstanceId);
+        int serviceId;
+        if (serviceInstanceInventory == null) {
+            serviceId = serviceInstanceInventory.getServiceId();
+        } else {
+            logger.warn("Can't found service by service instance id from cache, service instance id is: {}", serviceInstanceId);
+            return;
+        }
+
+        this.sendToCpuMetricProcess(serviceId, serviceInstanceId, minuteTimeBucket, metric.getCpu());
+        this.sendToMemoryMetricProcess(serviceId, serviceInstanceId, minuteTimeBucket, metric.getMemoryList());
+        this.sendToMemoryPoolMetricProcess(serviceId, serviceInstanceId, minuteTimeBucket, metric.getMemoryPoolList());
+        this.sendToGCMetricProcess(serviceId, serviceInstanceId, minuteTimeBucket, metric.getGcList());
     }
 
-    private void sendToCpuMetricProcess(int serviceInstanceId, long timeBucket, CPU cpu) {
+    private void sendToCpuMetricProcess(int serviceId, int serviceInstanceId, long timeBucket, CPU cpu) {
         ServiceInstanceJVMCPU serviceInstanceJVMCPU = new ServiceInstanceJVMCPU();
         serviceInstanceJVMCPU.setId(serviceInstanceId);
         serviceInstanceJVMCPU.setName(Const.EMPTY_STRING);
-        serviceInstanceJVMCPU.setServiceInstanceId(serviceInstanceId);
+        serviceInstanceJVMCPU.setServiceId(serviceId);
         serviceInstanceJVMCPU.setServiceName(Const.EMPTY_STRING);
         serviceInstanceJVMCPU.setUsePercent(cpu.getUsagePercent());
         serviceInstanceJVMCPU.setTimeBucket(timeBucket);
         sourceReceiver.receive(serviceInstanceJVMCPU);
     }
 
-    private void sendToGCMetricProcess(int serviceInstanceId, long timeBucket, List<GC> gcs) {
+    private void sendToGCMetricProcess(int serviceId, int serviceInstanceId, long timeBucket, List<GC> gcs) {
         gcs.forEach(gc -> {
             ServiceInstanceJVMGC serviceInstanceJVMGC = new ServiceInstanceJVMGC();
             serviceInstanceJVMGC.setId(serviceInstanceId);
             serviceInstanceJVMGC.setName(Const.EMPTY_STRING);
-            serviceInstanceJVMGC.setServiceInstanceId(serviceInstanceId);
+            serviceInstanceJVMGC.setServiceId(serviceId);
             serviceInstanceJVMGC.setServiceName(Const.EMPTY_STRING);
 
             switch (gc.getPhrase()) {
@@ -85,12 +92,12 @@ public class JVMSourceDispatcher {
         });
     }
 
-    private void sendToMemoryMetricProcess(int serviceInstanceId, long timeBucket, List<Memory> memories) {
+    private void sendToMemoryMetricProcess(int serviceId, int serviceInstanceId, long timeBucket, List<Memory> memories) {
         memories.forEach(memory -> {
             ServiceInstanceJVMMemory serviceInstanceJVMMemory = new ServiceInstanceJVMMemory();
             serviceInstanceJVMMemory.setId(serviceInstanceId);
             serviceInstanceJVMMemory.setName(Const.EMPTY_STRING);
-            serviceInstanceJVMMemory.setServiceInstanceId(serviceInstanceId);
+            serviceInstanceJVMMemory.setServiceId(serviceId);
             serviceInstanceJVMMemory.setServiceName(Const.EMPTY_STRING);
             serviceInstanceJVMMemory.setHeapStatus(memory.getIsHeap());
             serviceInstanceJVMMemory.setInit(memory.getInit());
@@ -102,14 +109,14 @@ public class JVMSourceDispatcher {
         });
     }
 
-    private void sendToMemoryPoolMetricProcess(int serviceInstanceId, long timeBucket,
+    private void sendToMemoryPoolMetricProcess(int serviceId, int serviceInstanceId, long timeBucket,
         List<MemoryPool> memoryPools) {
 
         memoryPools.forEach(memoryPool -> {
             ServiceInstanceJVMMemoryPool serviceInstanceJVMMemoryPool = new ServiceInstanceJVMMemoryPool();
             serviceInstanceJVMMemoryPool.setId(serviceInstanceId);
             serviceInstanceJVMMemoryPool.setName(Const.EMPTY_STRING);
-            serviceInstanceJVMMemoryPool.setServiceInstanceId(serviceInstanceId);
+            serviceInstanceJVMMemoryPool.setServiceId(serviceId);
             serviceInstanceJVMMemoryPool.setServiceName(Const.EMPTY_STRING);
 
             switch (memoryPool.getType()) {


### PR DESCRIPTION
Hi @peng-yongsheng @liuhaoyang 

I think I made a mistake in the current OAL tool, which also triggers some related receiver code issue.
All service instance scopes should add `service_id` rather than `service_instance_id`, because their `id`(`entity_id`) is service instance id. Also because of this, receiver set the wrong value to scope.

I am correcting the issue in this PR.

Notice, this issue wouldn't trigger any feature BUG at this moment, but it causes potential ones, if someone wants to do aggregation query based on all there sources.