### PR TITLE
Shutdown the OAP server when catch any exception.

### DIFF
--- a/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerStartUp.java
+++ b/oap-server/server-starter/src/main/java/org/apache/skywalking/oap/server/starter/OAPServerStartUp.java
@@ -20,7 +20,7 @@ package org.apache.skywalking.oap.server.starter;
 
 import org.apache.skywalking.oap.server.core.RunningMode;
 import org.apache.skywalking.oap.server.library.module.*;
-import org.apache.skywalking.oap.server.starter.config.*;
+import org.apache.skywalking.oap.server.starter.config.ApplicationConfigLoader;
 import org.apache.skywalking.oap.server.telemetry.TelemetryModule;
 import org.apache.skywalking.oap.server.telemetry.api.*;
 import org.slf4j.*;
@@ -45,14 +45,14 @@ public class OAPServerStartUp {
             manager.find(TelemetryModule.NAME).provider().getService(MetricCreator.class).createGauge("uptime",
                 "oap server start up time", MetricTag.EMPTY_KEY, MetricTag.EMPTY_VALUE)
                 // Set uptime to second
-                .setValue(System.currentTimeMillis() / 1000);
+                .setValue(System.currentTimeMillis() / 1000d);
 
             if (RunningMode.isInitMode()) {
                 logger.info("OAP starts up in init mode successfully, exit now...");
                 System.exit(0);
             }
-        } catch (ConfigFileNotFoundException | ModuleNotFoundException | ProviderNotFoundException | ServiceNotProvidedException | ModuleConfigException | ModuleStartException e) {
-            logger.error(e.getMessage(), e);
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
             System.exit(1);
         }
     }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [X] Bug fix
- [ ] New feature provided
- [ ] Improve performance

OAP server will shutdown after catch those exceptions: ConfigFileNotFoundException, ModuleNotFoundException, ProviderNotFoundException, ServiceNotProvidedException, ModuleConfigException, ModuleStartException. But if the exception is not included in this collection.  The OAP server will still running. This is wrong because of this will cause subsequent modules not to start properly.  Clusters will take unpredictable problems.