### PR TITLE
extract immutable object to reduce garbages

### DIFF
--- a/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/GraphQLQueryHandler.java
+++ b/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/GraphQLQueryHandler.java
@@ -30,6 +30,7 @@ import graphql.GraphQLError;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -51,6 +52,8 @@ public class GraphQLQueryHandler extends JettyJsonHandler {
     private static final String MESSAGE = "message";
 
     private final Gson gson = new Gson();
+    private final Type mapOfStringObjectType = new TypeToken<Map<String, Object>>() {
+    }.getType();
 
     private final String path;
 
@@ -75,8 +78,7 @@ public class GraphQLQueryHandler extends JettyJsonHandler {
 
         JsonObject requestJson = gson.fromJson(request.toString(), JsonObject.class);
 
-        return execute(requestJson.get(QUERY).getAsString(), gson.fromJson(requestJson.get(VARIABLES), new TypeToken<Map<String, Object>>() {
-        }.getType()));
+        return execute(requestJson.get(QUERY).getAsString(), gson.fromJson(requestJson.get(VARIABLES), mapOfStringObjectType));
     }
 
     private JsonObject execute(String request, Map<String, Object> variables) {


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues
no

___
### New feature or improvement
- Describe the details and related test reports.
https://github.com/apache/incubator-skywalking/blob/e93b3f0d16fd1b28e6342e4e179f313922e33757/oap-server/server-query-plugin/query-graphql-plugin/src/main/java/org/apache/skywalking/oap/query/graphql/GraphQLQueryHandler.java#L78

the `new TypeToken<Map<String, Object>>() {}.getType()` is just for type reference, there is no need to create one each time, extracting it as immutable field will avoid generating many garbages 