### PR TITLE
Add catalog to ScopeDeclaration annotation

### DIFF
--- a/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmModuleProvider.java
+++ b/oap-server/server-alarm-plugin/src/main/java/org/apache/skywalking/oap/server/core/alarm/provider/AlarmModuleProvider.java
@@ -25,6 +25,8 @@ import org.apache.skywalking.oap.server.library.module.*;
 import org.apache.skywalking.oap.server.library.util.ResourceUtils;
 
 public class AlarmModuleProvider extends ModuleProvider {
+    private NotifyHandler notifyHandler;
+
     @Override public String name() {
         return "default";
     }
@@ -46,7 +48,7 @@ public class AlarmModuleProvider extends ModuleProvider {
         }
         RulesReader reader = new RulesReader(applicationReader);
         Rules rules = reader.readRules();
-        NotifyHandler notifyHandler = new NotifyHandler(rules);
+        notifyHandler = new NotifyHandler(rules);
         notifyHandler.init(new AlarmStandardPersistence());
         this.registerServiceImplementation(IndicatorNotify.class, notifyHandler);
     }
@@ -55,7 +57,7 @@ public class AlarmModuleProvider extends ModuleProvider {
     }
 
     @Override public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
-
+        notifyHandler.initCache(getManager());
     }
 
     @Override public String[] requiredModules() {

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/IndicatorNotify.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/alarm/IndicatorNotify.java
@@ -32,5 +32,5 @@ import org.apache.skywalking.oap.server.library.module.Service;
  * @author wusheng
  */
 public interface IndicatorNotify extends Service {
-    void notify(MetaInAlarm indicatorName, Indicator indicator);
+    void notify(Indicator indicator);
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/DefaultScopeDefine.java
@@ -60,6 +60,17 @@ public class DefaultScopeDefine {
     public static final int SERVICE_INSTANCE_CLR_THREAD = 21;
     public static final int ENVOY_INSTANCE_METRIC = 22;
 
+    /**
+     * Catalog of scope, the indicator processor could use this to group all generated indicators by oal tool.
+     */
+    public static final String SERVICE_CATALOG_NAME = "SERVICE";
+    public static final String SERVICE_INSTANCE_CATALOG_NAME = "SERVICE_INSTANCE";
+    public static final String ENDPOINT_CATALOG_NAME = "ENDPOINT";
+
+    private static final Map<Integer, Boolean> SERVICE_CATALOG = new HashMap<>();
+    private static final Map<Integer, Boolean> SERVICE_INSTANCE_CATALOG = new HashMap<>();
+    private static final Map<Integer, Boolean> ENDPOINT_CATALOG = new HashMap<>();
+
     public static class Listener implements AnnotationListener {
         @Override public Class<? extends Annotation> annotation() {
             return ScopeDeclaration.class;
@@ -84,6 +95,19 @@ public class DefaultScopeDefine {
         }
         ID_2_NAME.put(id, name);
         NAME_2_ID.put(name, id);
+
+        String catalogName = declaration.catalog();
+        switch (catalogName) {
+            case SERVICE_CATALOG_NAME:
+                SERVICE_CATALOG.put(id, Boolean.TRUE);
+                break;
+            case SERVICE_INSTANCE_CATALOG_NAME:
+                SERVICE_INSTANCE_CATALOG.put(id, Boolean.TRUE);
+                break;
+            case ENDPOINT_CATALOG_NAME:
+                ENDPOINT_CATALOG.put(id, Boolean.TRUE);
+                break;
+        }
     }
 
     public static String nameOf(int id) {
@@ -105,5 +129,17 @@ public class DefaultScopeDefine {
     public static void reset() {
         NAME_2_ID.clear();
         ID_2_NAME.clear();
+    }
+
+    public static boolean inServiceCatalog(int scopeId) {
+        return SERVICE_CATALOG.containsKey(scopeId);
+    }
+
+    public static boolean inServiceInstanceCatalog(int scopeId) {
+        return SERVICE_INSTANCE_CATALOG.containsKey(scopeId);
+    }
+
+    public static boolean inEndpointCatalog(int scopeId) {
+        return ENDPOINT_CATALOG.containsKey(scopeId);
     }
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Endpoint.java
@@ -21,11 +21,12 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.*;
 
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.ENDPOINT;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.ENDPOINT_CATALOG_NAME;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = ENDPOINT, name = "Endpoint")
+@ScopeDeclaration(id = ENDPOINT, name = "Endpoint", catalog = ENDPOINT_CATALOG_NAME)
 public class Endpoint extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.ENDPOINT;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EnvoyInstanceMetric.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/EnvoyInstanceMetric.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.*;
 
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.ENVOY_INSTANCE_METRIC;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 
 /**
  * The envoy metrics. This group of metrics are in Prometheus metric format family.
@@ -29,7 +30,7 @@ import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.EN
  *
  * @author wusheng
  */
-@ScopeDeclaration(id = ENVOY_INSTANCE_METRIC, name = "EnvoyInstanceMetric")
+@ScopeDeclaration(id = ENVOY_INSTANCE_METRIC, name = "EnvoyInstanceMetric", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class EnvoyInstanceMetric extends Source {
     @Override public int scope() {
         return ENVOY_INSTANCE_METRIC;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ScopeDeclaration.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ScopeDeclaration.java
@@ -30,4 +30,5 @@ import java.lang.annotation.*;
 public @interface ScopeDeclaration {
     int id();
     String name();
+    String catalog() default "";
 }

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/Service.java
@@ -20,12 +20,12 @@ package org.apache.skywalking.oap.server.core.source;
 
 import lombok.*;
 
-import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.*;
 
 /**
  * @author wusheng, peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE, name = "Service")
+@ScopeDeclaration(id = SERVICE, name = "Service", catalog = SERVICE_CATALOG_NAME)
 public class Service extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstance.java
@@ -21,11 +21,12 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.*;
 
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE;
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE_INSTANCE, name = "ServiceInstance")
+@ScopeDeclaration(id = SERVICE_INSTANCE, name = "ServiceInstance", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstance extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRCPU.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRCPU.java
@@ -21,12 +21,13 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.Getter;
 import lombok.Setter;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CLR_CPU;
 
 /**
  * @author liuhaoyang
  **/
-@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_CPU, name = "ServiceInstanceCLRCPU")
+@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_CPU, name = "ServiceInstanceCLRCPU", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceCLRCPU extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_CLR_CPU;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRGC.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRGC.java
@@ -21,12 +21,13 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.Getter;
 import lombok.Setter;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CLR_GC;
 
 /**
  * @author liuhaoyang
  **/
-@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_GC, name = "ServiceInstanceCLRGC")
+@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_GC, name = "ServiceInstanceCLRGC", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceCLRGC extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_CLR_GC;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRThread.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceCLRThread.java
@@ -21,12 +21,13 @@ package org.apache.skywalking.oap.server.core.source;
 import lombok.Getter;
 import lombok.Setter;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CLR_THREAD;
 
 /**
  * @author liuhaoyang
  **/
-@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_THREAD, name = "ServiceInstanceCLRThread")
+@ScopeDeclaration(id = SERVICE_INSTANCE_CLR_THREAD, name = "ServiceInstanceCLRThread", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceCLRThread extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_CLR_THREAD;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMCPU.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMCPU.java
@@ -20,12 +20,13 @@ package org.apache.skywalking.oap.server.core.source;
 
 import lombok.*;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_JVM_CPU;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_CPU, name = "ServiceInstanceJVMCPU")
+@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_CPU, name = "ServiceInstanceJVMCPU", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceJVMCPU extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_JVM_CPU;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMGC.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMGC.java
@@ -20,12 +20,13 @@ package org.apache.skywalking.oap.server.core.source;
 
 import lombok.*;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_JVM_GC;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_GC, name = "ServiceInstanceJVMGC")
+@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_GC, name = "ServiceInstanceJVMGC", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceJVMGC extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_JVM_GC;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemory.java
@@ -20,12 +20,13 @@ package org.apache.skywalking.oap.server.core.source;
 
 import lombok.*;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_JVM_MEMORY;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_MEMORY, name = "ServiceInstanceJVMMemory")
+@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_MEMORY, name = "ServiceInstanceJVMMemory", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceJVMMemory extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_JVM_MEMORY;

--- a/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemoryPool.java
+++ b/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/source/ServiceInstanceJVMMemoryPool.java
@@ -20,12 +20,13 @@ package org.apache.skywalking.oap.server.core.source;
 
 import lombok.*;
 
+import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_CATALOG_NAME;
 import static org.apache.skywalking.oap.server.core.source.DefaultScopeDefine.SERVICE_INSTANCE_JVM_MEMORY_POOL;
 
 /**
  * @author peng-yongsheng
  */
-@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_MEMORY_POOL, name = "ServiceInstanceJVMMemoryPool")
+@ScopeDeclaration(id = SERVICE_INSTANCE_JVM_MEMORY_POOL, name = "ServiceInstanceJVMMemoryPool", catalog = SERVICE_INSTANCE_CATALOG_NAME)
 public class ServiceInstanceJVMMemoryPool extends Source {
     @Override public int scope() {
         return DefaultScopeDefine.SERVICE_INSTANCE_JVM_MEMORY_POOL;


### PR DESCRIPTION
Add `catalog` to ScopeDeclaration annotation. Make the alarm adapt to it. Now more metric could go through alarm, such as JVM, CLR.

Also, this pr is preparing for export. After we have the catalog, we could do export based on the catalog too.