### PR TITLE
Fixed UI default port

### DIFF
--- a/docs/en/Deploy-backend-in-standalone-mode.md
+++ b/docs/en/Deploy-backend-in-standalone-mode.md
@@ -22,7 +22,7 @@ You can simply tar/unzip and startup if ports 8080, 10800, 11800, 12800 are free
 
 You should keep the `config/application.yml` as default.
 
-- NOTICE: **In 5.0.0, startup.sh will start two processes, collector and UI, and UI uses 127.0.0.1:10800 as default.**
+- NOTICE: **In 5.0.0, startup.sh will start two processes, collector and UI, and UI uses 127.0.0.1:8080 as default.**
 
 ## Use Elastic Search instead of H2 as storage layer implementation
 Even in standalone mode, collector can run with Elastic Search as storage. If so, uncomment the `storage` section in `application.yml`, set the config right. The default configs fit for collector and Elasticsearch both running in same machine, and not cluster.


### PR DESCRIPTION
The default port seems to be 8080

Please answer these questions before submitting pull request

- Why submit this pull request?
- [ x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
UI default port seems to be 8080 but document is listed in 10800
- How to fix?
10800 -》 8080 
___
### New feature or improvement
- Describe the details and related test reports.
