### PR TITLE
Support compile project agent, backend, UI separately.

### DIFF
--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -17,7 +17,8 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
@@ -28,24 +29,47 @@
     <artifactId>apache-skywalking-apm-incubating</artifactId>
     <packaging>pom</packaging>
 
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.skywalking</groupId>
-            <artifactId>apm-agent-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.skywalking</groupId>
-            <artifactId>server-starter</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.skywalking</groupId>
-            <artifactId>apm-webapp</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.skywalking</groupId>
+                    <artifactId>apm-agent</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>backend</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.skywalking</groupId>
+                    <artifactId>server-starter</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>ui</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.skywalking</groupId>
+                    <artifactId>apm-webapp</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <finalName>apache-skywalking-apm-incubating-bin</finalName>
@@ -81,8 +105,12 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.tar.gz" tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.tar.gz" overwrite="true" />
-                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.zip" tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.zip" overwrite="true" />
+                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.tar.gz"
+                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.tar.gz"
+                                      overwrite="true"/>
+                                <copy file="${project.build.directory}/apache-skywalking-apm-incubating-bin.zip"
+                                      tofile="${project.basedir}/../dist/apache-skywalking-apm-incubating-bin.zip"
+                                      overwrite="true"/>
                             </tasks>
                         </configuration>
                     </execution>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -98,13 +98,25 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>clean</id>
+                        <phase>clean</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <tasks>
                                 <delete dir="${project.basedir}/../../skywalking-agent" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
                                 <mkdir dir="${project.basedir}/../../skywalking-agent" />
                                 <copy file="${project.build.directory}/skywalking-agent.jar" tofile="${project.basedir}/../../skywalking-agent/skywalking-agent.jar" overwrite="true" />
                                 <mkdir dir="${project.basedir}/../../skywalking-agent/config" />

--- a/docs/en/guides/How-to-build.md
+++ b/docs/en/guides/How-to-build.md
@@ -23,6 +23,18 @@ For each official Apache release, there is a complete and independent source cod
 1. Run `./mvnw clean package -DskipTests`
 1. All packages are in `/dist`.(.tar.gz for Linux and .zip for Windows).
 
+### Advanced compile
+SkyWalking is a complex maven project, including many modules, which could cause long compiling time. 
+If you just want to recompile part of the project, you have following options
+- Compile agent and package
+>  ./mvnw package -Pagent,dist
+- Compile backend and package
+>  ./mvnw package -Pbackend,dist
+- Compile UI and package
+>  ./mvnw package -Pui,dist
+
+
+
 ## Setup your IntelliJ IDEA
 1. Import the project as a maven project
 1. Run `./mvnw compile -Dmaven.test.skip=true` to compile project and generate source codes. Because we use gRPC and protobuf.

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,8 @@
     </parent>
 
     <modules>
-        <module>oap-server</module>
         <module>apm-commons</module>
-        <module>apm-sniffer</module>
-        <module>apm-application-toolkit</module>
         <module>apm-protocol</module>
-        <module>apm-webapp</module>
-        <module>apm-dist</module>
         <module>apm-checkstyle</module>
     </modules>
     <packaging>pom</packaging>
@@ -79,6 +74,46 @@
             <unsubscribe>commits-unsubscribe@skywalking.incubator.apache.org</unsubscribe>
         </mailingList>
     </mailingLists>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>apm-sniffer</module>
+                <module>apm-application-toolkit</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>backend</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>oap-server</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>ui</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>apm-webapp</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>dist</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>apm-dist</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
### Advanced compile
SkyWalking is a complex maven project, including many modules, which could cause long compiling time. 
If you just want to recompile part of the project, you have following options
- Compile agent and package
>  ./mvnw package -Pagent,dist
- Compile backend and package
>  ./mvnw package -Pbackend,dist
- Compile UI and package
>  ./mvnw package -Pui,dist

----------
Document updated. @ascrutae @liuhaoyang Could you run this on your env to recheck?

@liuhaoyang Could you ask someone try this on Windows?