### PR TITLE
Support shutdown the trace analysis.

### DIFF
--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceModuleProvider.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceModuleProvider.java
@@ -63,15 +63,19 @@ public class TraceModuleProvider extends ModuleProvider {
         moduleConfig.setDbLatencyThresholds(new DBLatencyThresholds(moduleConfig.getSlowDBAccessThreshold()));
 
         SegmentParserListenerManager listenerManager = new SegmentParserListenerManager();
-        listenerManager.add(new MultiScopesSpanListener.Factory());
-        listenerManager.add(new ServiceMappingSpanListener.Factory());
+        if (moduleConfig.isTraceAnalysis()) {
+            listenerManager.add(new MultiScopesSpanListener.Factory());
+            listenerManager.add(new ServiceMappingSpanListener.Factory());
+        }
         listenerManager.add(new SegmentSpanListener.Factory(moduleConfig.getSampleRate()));
 
         segmentProducer = new SegmentParse.Producer(getManager(), listenerManager, moduleConfig);
 
         listenerManager = new SegmentParserListenerManager();
-        listenerManager.add(new MultiScopesSpanListener.Factory());
-        listenerManager.add(new ServiceMappingSpanListener.Factory());
+        if (moduleConfig.isTraceAnalysis()) {
+            listenerManager.add(new MultiScopesSpanListener.Factory());
+            listenerManager.add(new ServiceMappingSpanListener.Factory());
+        }
         listenerManager.add(new SegmentSpanListener.Factory(moduleConfig.getSampleRate()));
 
         segmentProducerV2 = new SegmentParseV2.Producer(getManager(), listenerManager, moduleConfig);

--- a/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceServiceModuleConfig.java
+++ b/oap-server/server-receiver-plugin/skywalking-trace-receiver-plugin/src/main/java/org/apache/skywalking/oap/server/receiver/trace/provider/TraceServiceModuleConfig.java
@@ -39,4 +39,12 @@ public class TraceServiceModuleConfig extends ModuleConfig {
      */
     @Setter @Getter private String slowDBAccessThreshold = "default:200";
     @Setter @Getter private DBLatencyThresholds dbLatencyThresholds;
+    /**
+     * Analysis trace status.
+     *
+     * 1. Default(YES) means analysis all metric from trace.
+     *
+     * 2. NO means, only save trace, but metrics come other places, such as service mesh.
+     */
+    @Setter @Getter private boolean traceAnalysis = true;
 }


### PR DESCRIPTION
Add a new setting in `trace-receiver`
```
receiver-trace:
  default:
    bufferPath: ${SW_RECEIVER_BUFFER_PATH:../trace-buffer/}  # Path to trace buffer files, suggest to use absolute path
    bufferOffsetMaxFileSize: ${SW_RECEIVER_BUFFER_OFFSET_MAX_FILE_SIZE:100} # Unit is MB
    bufferDataMaxFileSize: ${SW_RECEIVER_BUFFER_DATA_MAX_FILE_SIZE:500} # Unit is MB
    bufferFileCleanWhenRestart: ${SW_RECEIVER_BUFFER_FILE_CLEAN_WHEN_RESTART:false}
    sampleRate: ${SW_TRACE_SAMPLE_RATE:10000} # The sample rate precision is 1/10000. 10000 means 100% sample in default.
    slowDBAccessThreshold: ${SW_SLOW_DB_THRESHOLD:default:200,mongodb:100} # The slow database access thresholds. Unit ms.
    traceAnalysis: false
```

**traceAnalysis**, default TRUE. Most people would use this, only turn it on when we need SkyWalking native trace, but not analysis it.