### PR TITLE
Integration test for elastic search client.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ language: java
 
 install:
   - jdk_switcher use oraclejdk8
-  - ./mvnw clean
   - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
-  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet
+  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ language: java
 
 install:
   - jdk_switcher use oraclejdk8
-  - ./mvnw clean install -Dmaven.test.skip=true --quiet
-  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
+#  - ./mvnw clean install -Dmaven.test.skip=true --quiet
+#  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
   - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent verify test org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ language: java
 
 install:
   - jdk_switcher use oraclejdk8
-  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
   - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet
+  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ language: java
 
 install:
   - jdk_switcher use oraclejdk8
-#  - ./mvnw clean install -Dmaven.test.skip=true --quiet
-#  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
-  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent verify test org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet
+  - ./mvnw clean
+  - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
+  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - jdk_switcher use oraclejdk8
   - ./mvnw clean install -Dmaven.test.skip=true --quiet
   - ./mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet
-  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent test org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet
+  - ./mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent verify test org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+pipeline {
+    agent {
+        label 'ubuntu'
+    }
+
+    tools {
+        jdk 'JDK 1.8 (latest)'
+    }
+
+    options {
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+        ))
+        timestamps()
+        skipStagesAfterUnstable()
+        timeout time: 30, unit: 'MINUTES'
+    }
+
+    stages {
+        stage('SCM Checkout') {
+            steps {
+                deleteDir()
+                checkout scm
+            }
+        }
+
+        stage('Check environment') {
+            steps {
+                sh 'env'
+                sh 'pwd'
+                sh 'ls'
+                sh 'git status'
+            }
+        }
+
+        stage('Run install') {
+            steps {
+                sh './mvnw org.jacoco:jacoco-maven-plugin:0.8.3:prepare-agent clean install org.jacoco:jacoco-maven-plugin:0.8.3:report coveralls:report --quiet --batch-mode -nsu'
+            }
+        }
+
+        stage('Run install') {
+            steps {
+                sh './mvnw javadoc:javadoc -Dmaven.test.skip=true --quiet'
+            }
+        }
+    }
+
+    post {
+        always {
+            junit '**/target/surefire-reports/*.xml'
+            deleteDir()
+        }
+    }
+}

--- a/oap-server/pom.xml
+++ b/oap-server/pom.xml
@@ -17,7 +17,8 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
@@ -69,6 +70,8 @@
         <zipkin.version>2.9.1</zipkin.version>
         <caffeine.version>2.6.2</caffeine.version>
         <okhttp.version>3.9.0</okhttp.version>
+
+        <maven-docker-plugin.version>0.28.0</maven-docker-plugin.version>
     </properties>
 
     <dependencies>
@@ -322,4 +325,39 @@
             <!-- -->
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${maven-docker-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>IT*.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/oap-server/server-library/library-client/pom.xml
+++ b/oap-server/server-library/library-client/pom.xml
@@ -17,7 +17,8 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>server-library</artifactId>
         <groupId>org.apache.skywalking</groupId>
@@ -54,4 +55,52 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <sourceMode>all</sourceMode>
+                    <logDate>default</logDate>
+                    <verbose>true</verbose>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-elasticsearch</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>elastic/elasticsearch:${elasticsearch.version}</name>
+                                    <alias>elastic-client-integration-test</alias>
+                                    <run>
+                                        <ports>
+                                            <port>9200:9200</port>
+                                        </ports>
+                                        <wait>
+                                            <log>started</log>
+                                            <time>30000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>remove-it-database</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ITElasticSearchClient.java
+++ b/oap-server/server-library/library-client/src/test/java/org/apache/skywalking/oap/server/library/client/elasticsearch/ITElasticSearchClient.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.oap.server.library.client.elasticsearch;
+
+import java.io.IOException;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.xcontent.*;
+import org.junit.*;
+
+/**
+ * @author peng-yongsheng
+ */
+public class ITElasticSearchClient {
+
+    @Test
+    public void test() throws IOException {
+        ElasticSearchClient client = new ElasticSearchClient("localhost:9200", null, null, null);
+        client.connect();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.field("key", "value");
+        builder.endObject();
+        client.forceInsert("test_index", "201904091521", builder);
+
+        GetResponse response = client.get("test_index", "201904091521");
+
+        Assert.assertTrue(response.getSource().containsKey("key"));
+        Assert.assertEquals("value", response.getSource().get("key"));
+    }
+}

--- a/oap-server/server-library/library-client/src/test/resources/log4j2.xml
+++ b/oap-server/server-library/library-client/src/test/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout charset="UTF-8" pattern="%d - %c -%-4r [%t] %-5p %x - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
SkyWalking is not a tools library, actually it's a system. Most of the codes work together with third party system, such as elasticsearch, zookeeper.  So, how to test them is a big trouble. 
Now, I attempt to test them with docker. The docker-maven-plugin will startup the docker image of elasticsearch server before integration test case running. This will let us write the test case code connect with the really elasticsearch server. 

Integration test class naming rule is: IT*.java. Don't worry, those class will not running in the maven test cycle.
Executing command line: mvm verify